### PR TITLE
Improve available provisioning config loading

### DIFF
--- a/qtoggleserver/frontend/js/api/devices.js
+++ b/qtoggleserver/frontend/js/api/devices.js
@@ -198,26 +198,24 @@ export function patchFirmware(version, url, override = false) {
 }
 
 /**
- * GET https://provisioning.qtoggle.io/config API function call.
+ * GET https://provisioning.qtoggle.io/config/available.json file.
  * @alias qtoggle.api.devices.getProvisioningConfig
- * @param {String} [prefix] configuration prefix
  * @returns {Promise}
  */
-export function getProvisioningConfigs(prefix = '') {
+export function getProvisioningConfigs() {
     return new Promise(function (resolve, reject) {
 
         AJAX.requestJSON(
-            'GET', `${PROVISIONING_CONFIG_URL}/${prefix}`, /* query = */ null, /* data = */ null,
+            'GET', `${PROVISIONING_CONFIG_URL}/available.json`, /* query = */ null, /* data = */ null,
             /* success = */ function (configs) {
-
-                /* Remove .json extension */
-                configs.forEach(function (config) {
-                    if (config['name'].endsWith('.json')) {
-                        config['name'] = config['name'].slice(0, -5)
+                let processedConfigs = Object.entries(configs).map(function ([key, value]) {
+                    return {
+                        'name': key,
+                        ...value
                     }
                 })
 
-                resolve(configs)
+                resolve(processedConfigs)
             },
             /* failure = */ function (data, status, msg, headers) {
                 reject(BaseAPI.APIError.fromHTTPResponse(data, status, msg))
@@ -228,7 +226,7 @@ export function getProvisioningConfigs(prefix = '') {
 }
 
 /**
- * GET https://provisioning.qtoggle.io/config/{config_name}.json API function call.
+ * GET https://provisioning.qtoggle.io/config/{config_name}.json file.
  * @alias qtoggle.api.devices.getProvisioningConfig
  * @param {String} configName desired configuration name
  * @returns {Promise}

--- a/qtoggleserver/frontend/js/cache.js
+++ b/qtoggleserver/frontend/js/cache.js
@@ -305,7 +305,14 @@ export function loadPrefs() {
 export function loadProvisioningConfigs() {
     logger.debug('loading provisioning configs')
 
-    return DevicesAPI.getProvisioningConfigs().then(function (p) {
+    return DevicesAPI.getProvisioningConfigs().catch(function (error) {
+
+        /* Ignore errors when fetching provisioning configs - they aren't important for the app's well functioning */
+
+        logger.errorStack('loading provisioning configs failed', error)
+        return []
+
+    }).then(function (p) {
 
         if (provisioningConfigs == null) {
             whenProvisioningConfigsCacheReady.fulfill()
@@ -313,11 +320,6 @@ export function loadProvisioningConfigs() {
         provisioningConfigs = p
 
         logger.debug('loaded provisioning configs')
-
-    }).catch(function (error) {
-
-        logger.errorStack('loading provisioning configs failed', error)
-        throw error
 
     })
 }


### PR DESCRIPTION
 * Frontend: use available.json to fetch available provisioning configs
 * Frontend: ignore errors when fetching provisioning config