### PR TITLE
slaves: Add support for updating hostname when renaming device

### DIFF
--- a/qtoggleserver/frontend/js/devices/device-form.js
+++ b/qtoggleserver/frontend/js/devices/device-form.js
@@ -322,12 +322,12 @@ class DeviceForm extends mix(PageForm).with(
     /**
      * Start waiting for device to come line.
      */
-    startWaitingDeviceOnline() {
+    startWaitingDeviceOnline(timeout = APIConstants.DEFAULT_SERVER_TIMEOUT) {
         this.setProgress()
 
         PromiseUtils.withTimeout(
             this.waitDeviceOnline(),
-            APIConstants.DEFAULT_SERVER_TIMEOUT * 1000
+            timeout * 1000
         ).catch(function (error) {
 
             if (error instanceof TimeoutError) {

--- a/qtoggleserver/frontend/js/devices/devices-section.js
+++ b/qtoggleserver/frontend/js/devices/devices-section.js
@@ -2,10 +2,11 @@
 import {gettext}        from '$qui/base/i18n.js'
 import {getCurrentPage} from '$qui/pages/pages.js'
 
-import * as AuthAPI    from '$app/api/auth.js'
-import * as Cache      from '$app/cache.js'
-import WaitDeviceMixin from '$app/common/wait-device-mixin.js'
-import {Section}       from '$app/sections.js'
+import * as AuthAPI      from '$app/api/auth.js'
+import * as APIConstants from '$app/api/constants.js'
+import * as Cache        from '$app/cache.js'
+import WaitDeviceMixin   from '$app/common/wait-device-mixin.js'
+import {Section}         from '$app/sections.js'
 
 import * as Devices from './devices.js'
 import DevicesTable from './devices-table.js'
@@ -103,7 +104,7 @@ class DevicesSection extends Section {
                         this.devicesTable.updateUI()
                         this.devicesTable.setSelectedDeviceName(device.name)
                         this.devicesTable.pushPage(deviceForm)
-                        deviceForm.startWaitingDeviceOnline()
+                        deviceForm.startWaitingDeviceOnline(APIConstants.LONG_SERVER_TIMEOUT)
                     }
                 }
 

--- a/qtoggleserver/utils/asyncio.py
+++ b/qtoggleserver/utils/asyncio.py
@@ -58,9 +58,14 @@ class ParallelCaller:
         except asyncio.CancelledError:
             pass
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
+        current_task = asyncio.current_task()
+
         for task in self._loop_tasks:
-            task.cancel()
+            if task is not current_task:
+                task.cancel()
+
+        await asyncio.gather(*[t for t in self._loop_tasks if t is not current_task])
 
 
 class Timer:


### PR DESCRIPTION
 * slaves/devices: Update host on device rename
 * slaves/devices: Reset device after updating hostname
 * utils/asyncio: Properly wait for ParallelCaller to stop
 * frontend/devices: Increase timeout when waiting for device rename