### PR TITLE
Implement Session-Id header usage

### DIFF
--- a/qtoggleserver/core/api/funcs/various.py
+++ b/qtoggleserver/core/api/funcs/various.py
@@ -1,6 +1,4 @@
 
-import re
-
 from typing import Dict, Optional
 
 from qtoggleserver import slaves
@@ -28,16 +26,13 @@ async def get_access(request: core_api.APIRequest, access_level: int) -> Dict[st
 @core_api.api_call(core_api.ACCESS_LEVEL_VIEWONLY)
 async def get_listen(
     request: core_api.APIRequest,
-    session_id: str,
     timeout: Optional[int],
     access_level: int
 ) -> GenericJSONList:
 
-    if session_id is None:
-        raise core_api.APIError(400, 'missing-field', field='session_id')
-
-    if not re.match('[a-zA-Z0-9]{1,32}', session_id):
-        raise core_api.APIError(400, 'invalid-field', field='session_id')
+    session_id = request.headers.get('Session-Id')
+    if not session_id:
+        raise core_api.APIError(400, 'missing-header', header='Session-Id')
 
     if timeout is not None:
         try:

--- a/qtoggleserver/core/reverse.py
+++ b/qtoggleserver/core/reverse.py
@@ -192,7 +192,7 @@ class Reverse:
         if api_response_dict:  # Answer request
             body_str = api_response_dict['body']
             headers['Status'] = f'{api_response_dict["status"]} {httputil.responses[api_response_dict["status"]]}'
-            headers['API-Call-Id'] = api_request_dict['api_call_id']
+            headers['Session-Id'] = api_request_dict['session_id']
 
         http_client = AsyncHTTPClient()
         request = HTTPRequest(
@@ -209,7 +209,7 @@ class Reverse:
                 'sending answer request to %s %s (API call id %s) to %s',
                 api_request_dict['method'],
                 api_request_dict['path'],
-                api_request_dict['api_call_id'],
+                api_request_dict['session_id'],
                 url
             )
 
@@ -260,16 +260,16 @@ class Reverse:
             raise InvalidConsumerRequestError('Missing Path header') from None
 
         try:
-            api_call_id = response.headers['API-Call-Id']
+            session_id = response.headers['Session-Id']
 
         except KeyError:
-            raise InvalidConsumerRequestError('Missing API-Call-Id header') from None
+            raise InvalidConsumerRequestError('Missing Session-Id header') from None
 
         return {
             'body': body,
             'method': method,
             'path': path,
-            'api_call_id': api_call_id,
+            'session_id': session_id,
             'access_level': access_level,
             'username': usr
         }

--- a/qtoggleserver/frontend/js/api/constants.js
+++ b/qtoggleserver/frontend/js/api/constants.js
@@ -42,6 +42,11 @@ export const KNOWN_ERRORS = [
     },
     {
         status: 400,
+        code: 'missing-header',
+        pretty: gettext('Missing header: %(header)s.')
+    },
+    {
+        status: 400,
         code: 'attribute-not-modifiable',
         pretty: gettext('Attribute "%(attribute)s" is not modifiable.')
     },
@@ -54,6 +59,11 @@ export const KNOWN_ERRORS = [
         status: 400,
         code: 'invalid-field',
         pretty: gettext('Invalid value for "%(field)s".')
+    },
+    {
+        status: 400,
+        code: 'invalid-header',
+        pretty: gettext('Invalid value for "%(header)s".')
     },
     {
         status: 400,

--- a/qtoggleserver/frontend/js/api/notifications.js
+++ b/qtoggleserver/frontend/js/api/notifications.js
@@ -267,7 +267,6 @@ function wait(firstQuick = false) {
 
     let timeout = (syncListenError || firstQuick) ? 1 : LISTEN_KEEPALIVE
     let query = {
-        session_id: BaseAPI.getSessionId(),
         timeout: timeout
     }
 

--- a/qtoggleserver/frontend/package-lock.json
+++ b/qtoggleserver/frontend/package-lock.json
@@ -117,9 +117,9 @@
             }
         },
         "@qtoggle/qui": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/@qtoggle/qui/-/qui-1.13.3.tgz",
-            "integrity": "sha512-nyhc6W0xQ4Lb8vHriRixim1jyUKtN59UxIDE4G8P+Ij3FzOUq9gEqZeUcbGNEiWZqmPE+KdiYN/dzz4KAHq1vQ==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/@qtoggle/qui/-/qui-1.13.4.tgz",
+            "integrity": "sha512-+sMFrT83noBES5axQJnlkdbKa4+Zi5YV9h6+fzYW3ZHd+Z7FQy6boVKw8xPlVXIKfmV+g3LPXYKew7721AKLXQ==",
             "requires": {
                 "jquery": "*",
                 "jquery-mousewheel": "*",


### PR DESCRIPTION
 * core/reverse: Use Session-Id instead of API-Call-Id
 * core/api: Use Session-Id header for listening sessions
 * frontend/api: Remove unused listen session_id query argument
 * slaves: Use Session-Id header for listening sessions
 * frontend/api: Add {invalid,missing}-header response code support