### PR TITLE
Add support for history API

### DIFF
--- a/extra/qtoggleserver.conf.sample
+++ b/extra/qtoggleserver.conf.sample
@@ -16,6 +16,8 @@ core = {
     max_client_time_skew = 300  # maximum accepted time skew when authenticating clients, in seconds
 
     backup_support = true
+    history_support = true
+    history_janitor_interval = 600
     listen_support = true
     sequences_support = true
     ssl_support = true

--- a/qtoggleserver/conf/settings.py
+++ b/qtoggleserver/conf/settings.py
@@ -50,6 +50,8 @@ class core:
     event_queue_size: int = 256
     max_client_time_skew: int = 300
     backup_support: bool = True
+    history_support: bool = True
+    history_janitor_interval: int = 600
     listen_support: bool = True
     sequences_support: bool = True
     ssl_support: bool = True

--- a/qtoggleserver/core/api/__init__.py
+++ b/qtoggleserver/core/api/__init__.py
@@ -72,7 +72,7 @@ class APIRequest:
         return self.handler.request.path
 
     @property
-    def query_arguments(self) -> Dict[str, str]:
+    def query(self) -> Dict[str, str]:
         return {k: self.handler.decode_argument(v[0]) for k, v in self.handler.request.query_arguments.items()}
 
     @property

--- a/qtoggleserver/core/device/__init__.py
+++ b/qtoggleserver/core/device/__init__.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 
 from qtoggleserver import persist
 from qtoggleserver.conf import settings
-from qtoggleserver.core.device import attrs as core_device_attrs
 from qtoggleserver.utils import json as json_utils
 from qtoggleserver.utils.cmd import run_get_cmd
 
@@ -93,14 +92,14 @@ def reset(preserve_attrs: Optional[List[str]] = None) -> None:
 
     preserved_attrs = {}
     for name in preserve_attrs:
-        preserved_attrs[name] = getattr(core_device_attrs, name, None)
+        preserved_attrs[name] = getattr(device_attrs, name, None)
 
     logger.debug('clearing persisted data')
     persist.remove('device')
-    importlib.reload(core_device_attrs)  # Reloads device attributes to default values
+    importlib.reload(device_attrs)  # Reloads device attributes to default values
 
     for name, value in preserved_attrs.items():
-        setattr(core_device_attrs, name, value)
+        setattr(device_attrs, name, value)
 
 
 async def init() -> None:

--- a/qtoggleserver/core/device/attrs.py
+++ b/qtoggleserver/core/device/attrs.py
@@ -14,7 +14,6 @@ from typing import Optional
 from qtoggleserver import system
 from qtoggleserver import version
 from qtoggleserver.conf import settings
-from qtoggleserver.core import api as core_api
 from qtoggleserver.core.typing import Attributes, AttributeDefinitions, GenericJSONDict
 from qtoggleserver.utils import json as json_utils
 from qtoggleserver.utils.cmd import run_set_cmd
@@ -344,6 +343,9 @@ def get_schema(loose: bool = False) -> GenericJSONDict:
 
 
 def get_attrs() -> Attributes:
+    from qtoggleserver.core import api as core_api
+    from qtoggleserver.core import history as core_history
+
     attrs = {
         'name': name,
         'display_name': display_name,
@@ -364,6 +366,9 @@ def get_attrs() -> Attributes:
 
     if settings.core.backup_support:
         flags.append('backup')
+
+    if core_history.is_enabled():
+        flags.append('history')
 
     if settings.core.listen_support:
         flags.append('listen')

--- a/qtoggleserver/core/history.py
+++ b/qtoggleserver/core/history.py
@@ -1,0 +1,182 @@
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from typing import Iterable, Optional
+
+from qtoggleserver import persist
+from qtoggleserver.conf import settings
+from qtoggleserver.core import events as core_events
+from qtoggleserver.core import ports as core_ports
+from qtoggleserver.core.typing import GenericJSONDict
+from qtoggleserver.utils import json as json_utils
+
+
+PERSIST_COLLECTION = 'value_history'
+
+logger = logging.getLogger(__name__)
+
+_history_event_handler: Optional[HistoryEventHandler] = None
+_sampling_task: Optional[asyncio.Task] = None
+_janitor_task: Optional[asyncio.Task] = None
+
+
+class HistoryEventHandler(core_events.Handler):
+    FIRE_AND_FORGET = False
+
+    async def handle_event(self, event: core_events.Event) -> None:
+        if not isinstance(event, core_events.ValueChange):
+            return  # We're only interested in port value changes
+
+        port = event.get_port()
+        history_interval = await port.get_history_interval()
+        if history_interval != -1:
+            return  # Only consider ports with history interval set to special -1 (on value change)
+
+        now = int(time.time() * 1000)
+
+        save_sample(port, now)
+        port.set_history_last_timestamp(now)
+
+
+async def sampling_task() -> None:
+    while True:
+        try:
+            await asyncio.sleep(1)
+
+            now = int(time.time() * 1000)
+            for port in core_ports.get_all():
+                if not port.is_enabled():
+                    continue
+
+                history_last_timestamp = port.get_history_last_timestamp()
+                history_interval = await port.get_history_interval()
+                if history_interval <= 0:  # Disabled or on value change
+                    continue
+
+                if now - history_last_timestamp < history_interval * 1000:
+                    continue
+
+                save_sample(port, now)
+                port.set_history_last_timestamp(now)
+
+        except asyncio.CancelledError:
+            logger.debug('sampling task cancelled')
+            break
+
+
+async def janitor_task() -> None:
+    while True:
+        try:
+            await asyncio.sleep(settings.core.history_janitor_interval)
+
+            now = int(time.time())
+            for port in core_ports.get_all():
+                history_retention = await port.get_history_retention()
+                if history_retention <= 0:
+                    continue
+
+                to_timestamp = (now - history_retention) * 1000
+                count = remove_samples(port, from_timestamp=0, to_timestamp=to_timestamp)
+                if count > 0:
+                    logger.debug('removed %d old samples of %s from history', count, port)
+
+        except asyncio.CancelledError:
+            logger.debug('janitor task cancelled')
+            break
+
+        except Exception as e:
+            logger.error('janitor task error: %s', e, exc_info=True)
+
+
+def is_enabled() -> bool:
+    return persist.is_history_supported() and settings.core.history_support
+
+
+def get_samples(
+    port: core_ports.BasePort,
+    from_timestamp: Optional[int] = None,
+    to_timestamp: Optional[int] = None,
+    limit: Optional[int] = None
+) -> Iterable[GenericJSONDict]:
+    filt = {
+        'pid': port.get_id(),
+    }
+
+    if from_timestamp is not None:
+        filt.setdefault('ts', {})['ge'] = from_timestamp
+
+    if to_timestamp is not None:
+        filt.setdefault('ts', {})['lt'] = to_timestamp
+
+    results = persist.query(PERSIST_COLLECTION, filt=filt, sort='ts', limit=limit)
+
+    return ({'value': r['val'], 'timestamp': r['ts']} for r in results)
+
+
+def save_sample(port: core_ports.BasePort, timestamp: int) -> None:
+    value = port.get_value()
+
+    if value is None:
+        logger.debug('skipping null sample of %s (timestamp = %s)', port, timestamp)
+        return
+
+    logger.debug('saving sample of %s (value = %s, timestamp = %s)', port, json_utils.dumps(value), timestamp)
+
+    record = {
+        'pid': port.get_id(),
+        'val': value,
+        'ts': timestamp
+    }
+
+    persist.insert(PERSIST_COLLECTION, record)
+
+
+def remove_samples(
+    port: core_ports.BasePort,
+    from_timestamp: Optional[int] = None,
+    to_timestamp: Optional[int] = None
+) -> int:
+    filt = {
+        'pid': port.get_id()
+    }
+
+    if from_timestamp is not None:
+        filt.setdefault('ts', {})['ge'] = from_timestamp
+
+    if to_timestamp is not None:
+        filt.setdefault('ts', {})['lt'] = to_timestamp
+
+    return persist.remove(PERSIST_COLLECTION, filt)
+
+
+def reset() -> None:
+    logger.debug('clearing persisted data')
+    persist.remove(PERSIST_COLLECTION)
+
+
+async def init() -> None:
+    global _history_event_handler
+    global _sampling_task
+    global _janitor_task
+
+    _history_event_handler = HistoryEventHandler()
+    core_events.register_handler(_history_event_handler)
+
+    _sampling_task = asyncio.create_task(sampling_task())
+    _janitor_task = asyncio.create_task(janitor_task())
+
+    persist.ensure_index(PERSIST_COLLECTION, 'ts')
+
+
+async def cleanup() -> None:
+    if _sampling_task:
+        _sampling_task.cancel()
+        await _sampling_task
+
+    if _janitor_task:
+        _janitor_task.cancel()
+        await _janitor_task

--- a/qtoggleserver/core/vports.py
+++ b/qtoggleserver/core/vports.py
@@ -82,11 +82,13 @@ def remove(port_id: str) -> None:
 
 
 def all_port_args() -> GenericJSONList:
-    return [{'driver': VirtualPort, 'id_': port_id, **args}
-            for port_id, args in _vport_args.items()]
+    return [
+        {'driver': VirtualPort, 'id_': port_id, **args}
+        for port_id, args in _vport_args.items()
+    ]
 
 
-def load() -> None:
+async def init() -> None:
     for entry in persist.query('vports'):
         _vport_args[entry['id']] = {
             'type_': entry.get('type') or core_ports.TYPE_NUMBER,
@@ -98,6 +100,9 @@ def load() -> None:
         }
 
         logger.debug('loaded virtual port settings for %s', entry['id'])
+
+    # Use raise_on_error=False because we prefer a partial successful startup rather than a failed one
+    await core_ports.load(all_port_args(), raise_on_error=False)
 
 
 def reset() -> None:

--- a/qtoggleserver/frontend/js/api/attrdefs.js
+++ b/qtoggleserver/frontend/js/api/attrdefs.js
@@ -9,6 +9,7 @@ import {TextAreaField}     from '$qui/forms/common-fields/common-fields.js'
 import {TextField}         from '$qui/forms/common-fields/common-fields.js'
 import * as DateUtils      from '$qui/utils/date.js'
 import * as ObjectUtils    from '$qui/utils/object.js'
+import * as StringUtils    from '$qui/utils/string.js'
 
 import {netmaskFromLen} from '$app/utils.js'
 import {netmaskToLen}   from '$app/utils.js'
@@ -19,6 +20,35 @@ import {WiFiSignalStrengthField} from './attrdef-fields.js'
 
 const IP_ADDRESS_PATTERN = /^([0-9]{1,3}\.){3}[0-9]{1,3}$/
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
+
+const HISTORY_INTERVAL_CHOICES = [
+    {display_name: gettext('disabled'), value: 0},
+    {display_name: gettext('when value changes'), value: -1},
+    {display_name: gettext('1 second'), value: 1},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d seconds'), {count: 5}), value: 5},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d seconds'), {count: 10}), value: 10},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d seconds'), {count: 30}), value: 30},
+    {display_name: gettext('1 minute'), value: 60},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d minutes'), {count: 5}), value: 300},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d minutes'), {count: 10}), value: 600},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d minutes'), {count: 15}), value: 900},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d minutes'), {count: 30}), value: 1800},
+    {display_name: gettext('1 hour'), value: 3600},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d hours'), {count: 4}), value: 14400},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d hours'), {count: 8}), value: 28800},
+    {display_name: StringUtils.formatPercent(gettext('%(count)d hours'), {count: 12}), value: 43200},
+    {display_name: gettext('1 day'), value: 86400}
+]
+
+const HISTORY_RETENTION_CHOICES = [
+    {display_name: gettext('forever'), value: 0},
+    {display_name: gettext('1 minute'), value: 60},
+    {display_name: gettext('1 hour'), value: 3600},
+    {display_name: gettext('1 day'), value: 86400},
+    {display_name: gettext('1 week'), value: 86400 * 7},
+    {display_name: gettext('1 month'), value: 86400 * 31},
+    {display_name: gettext('1 year'), value: 86400 * 366}
+]
 
 
 /**
@@ -680,6 +710,52 @@ export const STD_PORT_ATTRDEFS = {
         standard: true,
         optional: true,
         order: 270
+    },
+    history_interval: {
+        display_name: gettext('History Sampling Interval'),
+        description: gettext('Determines how often the port value will be sampled and saved to history.'),
+        type: 'number',
+        choices: HISTORY_INTERVAL_CHOICES,
+        modifiable: true,
+        standard: true,
+        optional: true,
+        separator: true,
+        order: 280
+    },
+    device_history_interval: {
+        /* display_name is added dynamically */
+        description: gettext(
+            'Determines how often the port value will be sampled and saved to history, directly on the device.'
+        ),
+        type: 'number',
+        choices: HISTORY_INTERVAL_CHOICES,
+        modifiable: true,
+        standard: true,
+        optional: true,
+        separator: true
+        /* order is added dynamically */
+    },
+    history_retention: {
+        display_name: gettext('History Retention Duration'),
+        description: gettext('Determines for how long historical data will be kept for this port.'),
+        type: 'number',
+        choices: HISTORY_RETENTION_CHOICES,
+        modifiable: true,
+        standard: true,
+        optional: true,
+        order: 290
+    },
+    device_history_retention: {
+        /* display_name is added dynamically */
+        description: gettext(
+            'Determines for how long historical data will be kept for this port, directly on the device.'
+        ),
+        type: 'number',
+        choices: HISTORY_RETENTION_CHOICES,
+        modifiable: true,
+        standard: true,
+        optional: true
+        /* order is added dynamically */
     }
 }
 

--- a/qtoggleserver/persist/__init__.py
+++ b/qtoggleserver/persist/__init__.py
@@ -1,7 +1,7 @@
 
 import logging
 
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from qtoggleserver.conf import settings
 from qtoggleserver.utils import conf as conf_utils
@@ -37,28 +37,46 @@ def _get_driver() -> BaseDriver:
     return _driver
 
 
+def is_history_supported() -> bool:
+    return _get_driver().is_history_supported()
+
+
 def query(
     collection: str,
     fields: Optional[List[str]] = None,
     filt: Optional[Dict[str, Any]] = None,
+    sort: Optional[Union[str, List[str]]] = None,
     limit: Optional[int] = None
 ) -> Iterable[Record]:
 
     if logger.getEffectiveLevel() <= logging.DEBUG:
         logger.debug(
-            'querying %s (%s) where %s',
+            'querying %s (%s) where %s (sort=%s, limit=%s)',
             collection,
             json_utils.dumps(fields) if fields else 'all fields',
-            json_utils.dumps(filt, allow_extended_types=True)
+            json_utils.dumps(filt, allow_extended_types=True),
+            json_utils.dumps(sort),
+            json_utils.dumps(limit),
         )
 
-    return _get_driver().query(collection, fields, filt or {}, limit)
+    filt = filt or {}
+    sort = sort or []
+    if isinstance(sort, str):
+        sort = [sort]
+
+    # Transform '-field' into (field, reverse)
+    sort = [
+        (s[1:], True) if s.startswith('-') else (s, False)
+        for s in sort
+    ]
+
+    return _get_driver().query(collection, fields, filt, sort, limit)
 
 
 def get(collection: str, id_: Id) -> Optional[Record]:
     logger.debug('getting record with id %s from %s', id_, collection)
 
-    records = list(_get_driver().query(collection, fields=None, filt={'id': id_}, limit=1))
+    records = list(_get_driver().query(collection, fields=None, filt={'id': id_}, sort=[], limit=1))
     if len(records) > 1:
         logger.warning('more than one record with same id %s found in collection %s', id_, collection)
 
@@ -71,7 +89,7 @@ def get(collection: str, id_: Id) -> Optional[Record]:
 def get_value(name: str, default: Optional[Any] = None) -> Any:
     logger.debug('getting value of %s', name)
 
-    records = list(_get_driver().query(name, fields=None, filt={}, limit=2))
+    records = list(_get_driver().query(name, fields=None, filt={}, sort=[], limit=2))
     if len(records) > 1:
         logger.warning('more than one record found in single-value collection %s', name)
 
@@ -144,6 +162,22 @@ def remove(collection: str, filt: Optional[Dict[str, Any]] = None) -> int:
     logger.debug('removed %s records from %s', count, collection)
 
     return count
+
+
+def ensure_index(collection: str, index: Union[str, List[str]]) -> None:
+    if isinstance(index, str):
+        index = [index]
+
+    # Transform '-field' into (field, reverse)
+    index = [
+        (i[1:], True) if i.startswith('-') else (i, False)
+        for i in index
+    ]
+
+    if logger.getEffectiveLevel() <= logging.DEBUG:
+        logger.debug('ensuring index %s in %s', json_utils.dumps(index), collection)
+
+    _get_driver().ensure_index(collection, index)
 
 
 async def cleanup() -> None:

--- a/qtoggleserver/persist/base.py
+++ b/qtoggleserver/persist/base.py
@@ -1,7 +1,7 @@
 
 import abc
 
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from .typing import Id, Record
 
@@ -13,9 +13,9 @@ class BaseDriver(metaclass=abc.ABCMeta):
         collection: str,
         fields: Optional[List[str]],
         filt: Dict[str, Any],
+        sort: List[Tuple[str, bool]],
         limit: Optional[int]
     ) -> Iterable[Record]:
-
         return []
 
     @abc.abstractmethod
@@ -34,6 +34,11 @@ class BaseDriver(metaclass=abc.ABCMeta):
     def remove(self, collection: str, filt: Dict[str, Any]) -> int:
         return 0  # Returns the number of removed records
 
-    @abc.abstractmethod
+    def ensure_index(self, collection: str, index: List[Tuple[str, bool]]) -> None:
+        pass
+
     def cleanup(self) -> None:
         pass
+
+    def is_history_supported(self) -> bool:
+        return False

--- a/qtoggleserver/slaves/api/funcs/discovered.py
+++ b/qtoggleserver/slaves/api/funcs/discovered.py
@@ -9,9 +9,16 @@ from .. import schema as api_schema
 
 
 @core_api.api_call(core_api.ACCESS_LEVEL_ADMIN)
-async def get_discovered(request: core_api.APIRequest, timeout: int) -> GenericJSONList:
+async def get_discovered(request: core_api.APIRequest) -> GenericJSONList:
+    timeout = request.query.get('timeout')
     if timeout is None:
         raise core_api.APIError(400, 'missing-field', field='timeout')
+
+    try:
+        timeout = int(timeout)
+
+    except ValueError:
+        raise core_api.APIError(400, 'invalid-field', field='timeout') from None
 
     discovered_devices = slaves_discover.get_discovered_devices()
     if discovered_devices is None:

--- a/qtoggleserver/slaves/devices.py
+++ b/qtoggleserver/slaves/devices.py
@@ -36,6 +36,7 @@ from .ports import SlavePort
 _MAX_PARALLEL_API_CALLS = 2
 _MAX_QUEUED_API_CALLS = 256
 _INVALID_EXPRESSION_FIELD_RE = re.compile(r'^((device_)*expression)$')
+_INVALID_HISTORY_FIELD_RE = re.compile(r'^((device_)*history_[a-z0-9_]+)$')
 _FWUPDATE_POLL_INTERVAL = 30
 _FWUPDATE_POLL_TIMEOUT = 300
 _NO_EVENT_DEVICE_ATTRS = ['uptime', 'date']
@@ -1537,10 +1538,11 @@ class Slave(logging_utils.LoggableMixin):
     def intercept_error(self, error: Exception) -> Exception:
         if isinstance(error, core_responses.HTTPError):
             # Slave expression attribute is known as "device_expression" on Master; we must adapt the corresponding
-            # error here by prepending a(nother) "device_"
+            # error here by prepending a(nother) "device_"; the sample applies to history_* attributes.
+
             if error.code == 'invalid-field':
                 field = error.params.get('field', '')
-                m = _INVALID_EXPRESSION_FIELD_RE.match(field)
+                m = _INVALID_EXPRESSION_FIELD_RE.match(field) or _INVALID_HISTORY_FIELD_RE.match(field)
                 if m:
                     params = dict(error.params)
                     params['field'] = 'device_' + m.group(1)

--- a/qtoggleserver/web/handlers.py
+++ b/qtoggleserver/web/handlers.py
@@ -236,7 +236,7 @@ class BackupEndpointsHandler(APIHandler):
 
 class AccessHandler(APIHandler):
     async def get(self) -> None:
-        await self.call_api_func(core_api_funcs.get_access, access_level=self.access_level)
+        await self.call_api_func(core_api_funcs.get_access)
 
 
 class SlaveDevicesHandler(APIHandler):
@@ -267,23 +267,14 @@ class SlaveDeviceEventsHandler(APIHandler):
 
 class SlaveDeviceForwardHandler(APIHandler):
     async def get(self, name: str, path: str) -> None:
-        await self.call_api_func(
-            slaves_api_funcs.slave_device_forward,
-            name=name,
-            method=self.request.method,
-            path=path
-        )
+        await self.call_api_func(slaves_api_funcs.slave_device_forward, name=name, path=path)
 
     post = patch = put = delete = get
 
 
 class DiscoveredHandler(APIHandler):
     async def get(self) -> None:
-        timeout = self.get_argument('timeout', None)
-        if timeout:
-            timeout = int(timeout)
-
-        await self.call_api_func(slaves_api_funcs.get_discovered, timeout=timeout)
+        await self.call_api_func(slaves_api_funcs.get_discovered)
 
     async def delete(self) -> None:
         await self.call_api_func(slaves_api_funcs.delete_discovered, default_status=204)
@@ -332,6 +323,14 @@ class PortSequenceHandler(APIHandler):
         await self.call_api_func(core_api_funcs.patch_port_sequence, port_id=port_id, default_status=204)
 
 
+class PortHistoryHandler(APIHandler):
+    async def get(self, port_id: str) -> None:
+        await self.call_api_func(core_api_funcs.get_port_history, port_id=port_id)
+
+    async def delete(self, port_id: str) -> None:
+        await self.call_api_func(core_api_funcs.delete_port_history, port_id=port_id, default_status=204)
+
+
 class WebhooksHandler(APIHandler):
     async def get(self) -> None:
         await self.call_api_func(core_api_funcs.get_webhooks)
@@ -342,15 +341,7 @@ class WebhooksHandler(APIHandler):
 
 class ListenHandler(APIHandler):
     async def get(self) -> None:
-        timeout = self.get_argument('timeout', None)
-        if timeout:
-            timeout = int(timeout)
-
-        await self.call_api_func(
-            core_api_funcs.get_listen,
-            timeout=timeout,
-            access_level=self.access_level
-        )
+        await self.call_api_func(core_api_funcs.get_listen)
 
 
 class ReverseHandler(APIHandler):

--- a/qtoggleserver/web/server.py
+++ b/qtoggleserver/web/server.py
@@ -8,6 +8,7 @@ from qui.web import tornado as qui_tornado
 
 from qtoggleserver import system
 from qtoggleserver.conf import settings
+from qtoggleserver.core import history
 from qtoggleserver.slaves.discover import is_enabled as is_discover_enabled
 from qtoggleserver.web import handlers
 
@@ -62,6 +63,11 @@ def _make_routing_table() -> List[URLSpec]:
     if settings.core.sequences_support:
         handlers_list += [
             URLSpec(r'^/api/ports/(?P<port_id>[A-Za-z0-9_.-]+)/sequence/?$', handlers.PortSequenceHandler)
+        ]
+
+    if history.is_enabled():
+        handlers_list += [
+            URLSpec(r'^/api/ports/(?P<port_id>[A-Za-z0-9_.-]+)/history/?$', handlers.PortHistoryHandler),
         ]
 
     if settings.core.backup_support:

--- a/tests/qtoggleserver/persist/data.py
+++ b/tests/qtoggleserver/persist/data.py
@@ -5,21 +5,24 @@ COLL2 = 'coll2'
 RECORD1 = {
     'string_key': 'value1',
     'int_key': 1,
-    'float_key': 1.123,
+    'float_key': 3.123,
     'bool_key': True,
-    'null_key': None
+    'null_key': None,
+    'non_unique_key': 'unique_b'
 }
 
 RECORD2 = {
     'string_key': 'value2',
     'int_key': 2,
-    'float_key': 2.234,
-    'bool_key': False
+    'float_key': 1.234,
+    'bool_key': False,
+    'non_unique_key': 'unique_a'
 }
 
 RECORD3 = {
     'string_key': 'value3',
     'int_key': 3,
-    'float_key': 3.345,
-    'bool_key': False
+    'float_key': 2.345,
+    'bool_key': False,
+    'non_unique_key': 'unique_b'
 }

--- a/tests/qtoggleserver/persist/query.py
+++ b/tests/qtoggleserver/persist/query.py
@@ -9,16 +9,16 @@ def test_query_full(driver: BaseDriver) -> None:
     driver.insert(data.COLL1, data.RECORD2)
     driver.insert(data.COLL1, data.RECORD3)
 
-    result = driver.query(data.COLL1, fields=None, filt={}, limit=None)
+    result = driver.query(data.COLL1, fields=None, filt={}, sort=[], limit=None)
     assert len(list(result)) == 3
 
 
-def test_query_specific_id(driver: BaseDriver) -> None:
+def test_query_filter_id(driver: BaseDriver) -> None:
     driver.insert(data.COLL1, data.RECORD1)
     driver.insert(data.COLL1, data.RECORD2)
     id3 = driver.insert(data.COLL1, data.RECORD3)
 
-    results = driver.query(data.COLL1, fields=None, filt={'id': id3}, limit=None)
+    results = driver.query(data.COLL1, fields=None, filt={'id': id3}, sort=[], limit=None)
     results = list(results)
     assert len(results) == 1
 
@@ -26,12 +26,18 @@ def test_query_specific_id(driver: BaseDriver) -> None:
     assert results[0] == record3
 
 
-def test_query_simple_filter(driver: BaseDriver) -> None:
+def test_query_filter_simple(driver: BaseDriver) -> None:
     driver.insert(data.COLL1, data.RECORD1)
     driver.insert(data.COLL1, data.RECORD2)
     driver.insert(data.COLL1, data.RECORD3)
 
-    results = driver.query(data.COLL1, fields=None, filt={'string_key': data.RECORD2['string_key']}, limit=None)
+    results = driver.query(
+        data.COLL1,
+        fields=None,
+        filt={'string_key': data.RECORD2['string_key']},
+        sort=[],
+        limit=None
+    )
     results = list(results)
     assert len(results) == 1
 
@@ -40,12 +46,115 @@ def test_query_simple_filter(driver: BaseDriver) -> None:
     assert result0 == data.RECORD2
 
 
+def test_query_filter_ge_lt(driver: BaseDriver) -> None:
+    id1 = driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={'int_key': {'ge': 1, 'lt': 3}}, sort=[], limit=None)
+    results = list(results)
+    assert len(results) == 2
+
+    results.sort(key=lambda r: r['int_key'])
+
+    assert results[0] == dict(data.RECORD1, id=id1)
+    assert results[1] == dict(data.RECORD2, id=id2)
+
+
+def test_query_filter_gt_le(driver: BaseDriver) -> None:
+    driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    id3 = driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={'int_key': {'gt': 1, 'le': 3}}, sort=[], limit=None)
+    results = list(results)
+    assert len(results) == 2
+
+    results.sort(key=lambda r: r['int_key'])
+
+    assert results[0] == dict(data.RECORD2, id=id2)
+    assert results[1] == dict(data.RECORD3, id=id3)
+
+
+def test_query_filter_in(driver: BaseDriver) -> None:
+    driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    id3 = driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={'int_key': {'in': [2, 3]}}, sort=[], limit=None)
+    results = list(results)
+    assert len(results) == 2
+
+    results.sort(key=lambda r: r['int_key'])
+
+    assert results[0] == dict(data.RECORD2, id=id2)
+    assert results[1] == dict(data.RECORD3, id=id3)
+
+
+def test_query_sort_simple(driver: BaseDriver) -> None:
+    id1 = driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    id3 = driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={}, sort=[('int_key', False)], limit=None)
+    results = list(results)
+    assert len(results) == 3
+
+    assert results[0]['id'] == id1
+    assert results[1]['id'] == id2
+    assert results[2]['id'] == id3
+
+
+def test_query_sort_desc(driver: BaseDriver) -> None:
+    id1 = driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    id3 = driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={}, sort=[('int_key', True)], limit=None)
+    results = list(results)
+    assert len(results) == 3
+
+    assert results[0]['id'] == id3
+    assert results[1]['id'] == id2
+    assert results[2]['id'] == id1
+
+
+def test_query_sort_composite(driver: BaseDriver) -> None:
+    id1 = driver.insert(data.COLL1, data.RECORD1)
+    id2 = driver.insert(data.COLL1, data.RECORD2)
+    id3 = driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(
+        data.COLL1,
+        fields=None,
+        filt={},
+        sort=[('non_unique_key', False), ('int_key', True)],
+        limit=None
+    )
+    results = list(results)
+    assert len(results) == 3
+
+    assert results[0]['id'] == id2
+    assert results[1]['id'] == id3
+    assert results[2]['id'] == id1
+
+
+def test_query_limit(driver: BaseDriver) -> None:
+    driver.insert(data.COLL1, data.RECORD1)
+    driver.insert(data.COLL1, data.RECORD2)
+    driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={}, sort=[], limit=2)
+    results = list(results)
+    assert len(results) == 2
+
+
 def test_query_fields(driver: BaseDriver) -> None:
     driver.insert(data.COLL1, data.RECORD1)
     driver.insert(data.COLL1, data.RECORD2)
     driver.insert(data.COLL1, data.RECORD3)
 
-    results = driver.query(data.COLL1, fields=['int_key', 'bool_key'], filt={}, limit=None)
+    results = driver.query(data.COLL1, fields=['int_key', 'bool_key'], filt={}, sort=[], limit=None)
     results = list(results)
     assert len(results) == 3
 
@@ -53,3 +162,26 @@ def test_query_fields(driver: BaseDriver) -> None:
         assert len(result) == 2
         assert 'int_key' in result
         assert 'bool_key' in result
+
+
+def test_query_filter_limit(driver: BaseDriver) -> None:
+    driver.insert(data.COLL1, data.RECORD1)
+    driver.insert(data.COLL1, data.RECORD2)
+    driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=None, filt={'int_key': {'gt': 1}}, sort=[], limit=1)
+    results = list(results)
+    assert len(results) == 1
+
+
+def test_query_inexistent_field(driver: BaseDriver) -> None:
+    driver.insert(data.COLL1, data.RECORD1)
+    driver.insert(data.COLL1, data.RECORD2)
+    driver.insert(data.COLL1, data.RECORD3)
+
+    results = driver.query(data.COLL1, fields=['int_key', 'inexistent_key'], filt={}, sort=[], limit=None)
+    assert len(list(results)) == 3
+
+    for result in results:
+        assert len(result) == 1
+        assert 'int_key' in result

--- a/tests/qtoggleserver/persist/test_json.py
+++ b/tests/qtoggleserver/persist/test_json.py
@@ -29,13 +29,49 @@ def test_query_full(driver: BaseDriver) -> None:
     query.test_query_full(driver)
 
 
-def test_query_specific_id(driver: BaseDriver) -> None:
-    query.test_query_specific_id(driver)
+def test_query_filter_id(driver: BaseDriver) -> None:
+    query.test_query_filter_id(driver)
 
 
-def test_query_simple_filter(driver: BaseDriver) -> None:
-    query.test_query_simple_filter(driver)
+def test_query_filter_simple(driver: BaseDriver) -> None:
+    query.test_query_filter_simple(driver)
+
+
+def test_query_filter_ge_lt(driver: BaseDriver) -> None:
+    query.test_query_filter_ge_lt(driver)
+
+
+def test_query_filter_gt_le(driver: BaseDriver) -> None:
+    query.test_query_filter_gt_le(driver)
+
+
+def test_query_filter_in(driver: BaseDriver) -> None:
+    query.test_query_filter_in(driver)
+
+
+def test_query_sort_simple(driver: BaseDriver) -> None:
+    query.test_query_sort_simple(driver)
+
+
+def test_query_sort_desc(driver: BaseDriver) -> None:
+    query.test_query_sort_desc(driver)
+
+
+def test_query_sort_composite(driver: BaseDriver) -> None:
+    query.test_query_sort_composite(driver)
+
+
+def test_query_limit(driver: BaseDriver) -> None:
+    query.test_query_limit(driver)
 
 
 def test_query_fields(driver: BaseDriver) -> None:
     query.test_query_fields(driver)
+
+
+def test_query_filter_limit(driver: BaseDriver) -> None:
+    query.test_query_filter_limit(driver)
+
+
+def test_query_inexistent_field(driver: BaseDriver) -> None:
+    query.test_query_inexistent_field(driver)

--- a/tests/qtoggleserver/persist/test_mongo.py
+++ b/tests/qtoggleserver/persist/test_mongo.py
@@ -1,5 +1,6 @@
 
 import mongomock
+import pymongo
 import pytest
 
 from qtoggleserver.drivers.persist import mongo
@@ -10,7 +11,7 @@ from . import query
 
 @pytest.fixture
 def driver(monkeypatch) -> BaseDriver:
-    monkeypatch.setattr(mongo, 'MongoClient', mongomock.MongoClient)
+    monkeypatch.setattr(pymongo, 'MongoClient', mongomock.MongoClient)
     return mongo.MongoDriver()
 
 
@@ -18,13 +19,49 @@ def test_query_full(driver: BaseDriver) -> None:
     query.test_query_full(driver)
 
 
-def test_query_specific_id(driver: BaseDriver) -> None:
-    query.test_query_specific_id(driver)
+def test_query_filter_id(driver: BaseDriver) -> None:
+    query.test_query_filter_id(driver)
 
 
-def test_query_simple_filter(driver: BaseDriver) -> None:
-    query.test_query_simple_filter(driver)
+def test_query_filter_simple(driver: BaseDriver) -> None:
+    query.test_query_filter_simple(driver)
+
+
+def test_query_filter_ge_lt(driver: BaseDriver) -> None:
+    query.test_query_filter_ge_lt(driver)
+
+
+def test_query_filter_gt_le(driver: BaseDriver) -> None:
+    query.test_query_filter_gt_le(driver)
+
+
+def test_query_filter_in(driver: BaseDriver) -> None:
+    query.test_query_filter_in(driver)
+
+
+def test_query_sort_simple(driver: BaseDriver) -> None:
+    query.test_query_sort_simple(driver)
+
+
+def test_query_sort_desc(driver: BaseDriver) -> None:
+    query.test_query_sort_desc(driver)
+
+
+def test_query_sort_composite(driver: BaseDriver) -> None:
+    query.test_query_sort_composite(driver)
+
+
+def test_query_limit(driver: BaseDriver) -> None:
+    query.test_query_limit(driver)
 
 
 def test_query_fields(driver: BaseDriver) -> None:
     query.test_query_fields(driver)
+
+
+def test_query_filter_limit(driver: BaseDriver) -> None:
+    query.test_query_filter_limit(driver)
+
+
+def test_query_inexistent_field(driver: BaseDriver) -> None:
+    query.test_query_inexistent_field(driver)

--- a/tests/qtoggleserver/persist/test_redis.py
+++ b/tests/qtoggleserver/persist/test_redis.py
@@ -20,13 +20,49 @@ def test_query_full(driver: BaseDriver) -> None:
     query.test_query_full(driver)
 
 
-def test_query_specific_id(driver: BaseDriver) -> None:
-    query.test_query_specific_id(driver)
+def test_query_filter_id(driver: BaseDriver) -> None:
+    query.test_query_filter_id(driver)
 
 
-def test_query_simple_filter(driver: BaseDriver) -> None:
-    query.test_query_simple_filter(driver)
+def test_query_filter_simple(driver: BaseDriver) -> None:
+    query.test_query_filter_simple(driver)
+
+
+def test_query_filter_ge_lt(driver: BaseDriver) -> None:
+    query.test_query_filter_ge_lt(driver)
+
+
+def test_query_filter_gt_le(driver: BaseDriver) -> None:
+    query.test_query_filter_gt_le(driver)
+
+
+def test_query_filter_in(driver: BaseDriver) -> None:
+    query.test_query_filter_in(driver)
+
+
+def test_query_sort_simple(driver: BaseDriver) -> None:
+    query.test_query_sort_simple(driver)
+
+
+def test_query_sort_desc(driver: BaseDriver) -> None:
+    query.test_query_sort_desc(driver)
+
+
+def test_query_sort_composite(driver: BaseDriver) -> None:
+    query.test_query_sort_composite(driver)
+
+
+def test_query_limit(driver: BaseDriver) -> None:
+    query.test_query_limit(driver)
 
 
 def test_query_fields(driver: BaseDriver) -> None:
     query.test_query_fields(driver)
+
+
+def test_query_filter_limit(driver: BaseDriver) -> None:
+    query.test_query_filter_limit(driver)
+
+
+def test_query_inexistent_field(driver: BaseDriver) -> None:
+    query.test_query_inexistent_field(driver)


### PR DESCRIPTION
 * persist: Add history supported flag
 * Add history setting & device flag
 * core/ports: Add support for dynamically enabling attrdefs
 * core/ports: Add support for history attributes
 * frontend/api: Add support for history attributes
 * slaves: Add support for master/slave history attributes
 * persist/mongo: Add extended filtering support
 * persist/redis: Add extended filtering support
 * persist/json: Add extended filtering support
 * core/history: Implement sampling loop
 * core/history: Implement janitor loop
 * core/history: Add reset support
 * settings: Add core.history_janitor_interval
 * core/api: Add history API calls
 * Reorganize query arguments usage in API calls