### PR TITLE
frontend: Add support for port history chart

### DIFF
--- a/qtoggleserver/core/api/funcs/ports.py
+++ b/qtoggleserver/core/api/funcs/ports.py
@@ -448,7 +448,7 @@ async def get_port_history(request: core_api.APIRequest, port_id: str) -> Generi
         except ValueError:
             raise core_api.APIError(400, 'invalid-field', field='limit') from None
 
-        if limit < 1 or limit > 1000:
+        if limit < 1 or limit > 10000:
             raise core_api.APIError(400, 'invalid-field', field='limit')
 
     samples = core_history.get_samples(port, from_timestamp, to_timestamp, limit)

--- a/qtoggleserver/core/history.py
+++ b/qtoggleserver/core/history.py
@@ -80,9 +80,8 @@ async def janitor_task() -> None:
                     continue
 
                 to_timestamp = (now - history_retention) * 1000
-                count = remove_samples(port, from_timestamp=0, to_timestamp=to_timestamp, background=True)
-                if count > 0:
-                    logger.debug('removed %d old samples of %s from history', count, port)
+                logger.debug('removing old samples of %s from history', port)
+                remove_samples(port, from_timestamp=0, to_timestamp=to_timestamp, background=True)
 
         except asyncio.CancelledError:
             logger.debug('janitor task cancelled')

--- a/qtoggleserver/frontend/img/qtoggle-icons.svg
+++ b/qtoggleserver/frontend/img/qtoggle-icons.svg
@@ -20,9 +20,9 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="269.68051"
-     inkscape:cy="11.507952"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="189.63758"
+     inkscape:cy="44.161034"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -615,645 +615,645 @@
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path4640-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1088"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path4640-7-9"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,748.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,748.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1402-3"
        inkscape:connector-curvature="0" />
     <path
        id="path1420"
-       d="m 368,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="754.51971"
        id="circle1422"
        style="display:inline;opacity:1;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1452"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1458"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1470"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1511"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="path998"
-       cx="503"
+       cx="823"
        cy="754.51971"
        r="2" />
     <path
        sodipodi:nodetypes="cscscssssssssssss"
        inkscape:connector-curvature="0"
        id="path1024"
-       d="m 272,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1026"
-       d="m 304,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1028"
-       d="m 336,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1030"
-       d="m 336,620.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,620.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        style="display:inline;opacity:1;fill:#444444;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 368,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1032" />
     <circle
        style="display:inline;opacity:1;fill:#444444;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1034"
        cy="626.51971"
-       cx="368"
+       cx="688"
        r="6" />
     <path
        inkscape:connector-curvature="0"
        id="path1036"
-       d="m 400,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1038"
-       d="m 432,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1040"
-       d="m 496,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1042"
-       d="m 464.00002,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <circle
        r="2"
        cy="626.51971"
-       cx="503"
+       cx="823"
        id="circle1044"
        style="opacity:1;fill:#444444;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path1046"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1048"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1050"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,652.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,652.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1053"
        inkscape:connector-curvature="0" />
     <path
        id="path1055"
-       d="m 368,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="658.51971"
        id="circle1057"
        style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1059"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1061"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1063"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1065"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1067"
-       cx="503"
+       cx="823"
        cy="658.51971"
        r="2" />
     <path
        sodipodi:nodetypes="cscscssssssssssss"
        inkscape:connector-curvature="0"
        id="path1070"
-       d="m 272,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1072"
-       d="m 304,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1074"
-       d="m 336,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1076"
-       d="m 336,684.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,684.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        style="display:inline;opacity:1;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 368,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1078" />
     <circle
        style="display:inline;opacity:1;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1080"
        cy="690.51971"
-       cx="368"
+       cx="688"
        r="6" />
     <path
        inkscape:connector-curvature="0"
        id="path1082"
-       d="m 400,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1084"
-       d="m 432,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1086"
-       d="m 496,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1091"
-       d="m 464.00002,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <circle
        r="2"
        cy="690.51971"
-       cx="503"
+       cx="823"
        id="circle1093"
        style="opacity:1;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path1095"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1097"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1099"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,716.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,716.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1101"
        inkscape:connector-curvature="0" />
     <path
        id="path1103"
-       d="m 368,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="722.51971"
        id="circle1105"
        style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1107"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1109"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1111"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1113"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#eff7ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1115"
-       cx="503"
+       cx="823"
        cy="722.51971"
        r="2" />
     <path
        sodipodi:nodetypes="cscscssssssssssss"
        inkscape:connector-curvature="0"
        id="path1117"
-       d="m 272,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1119"
-       d="m 304,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1121"
-       d="m 336,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1123"
-       d="m 336,908.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,908.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        style="display:inline;opacity:1;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 368,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1125" />
     <circle
        style="display:inline;opacity:1;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1127"
        cy="914.51971"
-       cx="368"
+       cx="688"
        r="6" />
     <path
        inkscape:connector-curvature="0"
        id="path1129"
-       d="m 400,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1131"
-       d="m 432,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1133"
-       d="m 496,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1135"
-       d="m 464.00002,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <circle
        r="2"
        cy="914.51971"
-       cx="503"
+       cx="823"
        id="circle1137"
        style="opacity:1;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path1139"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1141"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1143"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,780.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,780.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1145"
        inkscape:connector-curvature="0" />
     <path
        id="path1147"
-       d="m 368,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="786.51971"
        id="circle1149"
        style="display:inline;opacity:1;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1151"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1153"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1155"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1157"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1159"
-       cx="503"
+       cx="823"
        cy="786.51971"
        r="2" />
     <path
        sodipodi:nodetypes="cscscssssssssssss"
        inkscape:connector-curvature="0"
        id="path1161"
-       d="m 272,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1163"
-       d="m 304,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1165"
-       d="m 336,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1167"
-       d="m 336,812.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,812.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        style="display:inline;opacity:1;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 368,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1169" />
     <circle
        style="display:inline;opacity:1;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1171"
        cy="818.51971"
-       cx="368"
+       cx="688"
        r="6" />
     <path
        inkscape:connector-curvature="0"
        id="path1173"
-       d="m 400,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1175"
-       d="m 432,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1177"
-       d="m 496,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1179"
-       d="m 464.00002,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <circle
        r="2"
        cy="818.51971"
-       cx="503"
+       cx="823"
        id="circle1181"
        style="opacity:1;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path1183"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1185"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1187"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,844.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,844.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1189"
        inkscape:connector-curvature="0" />
     <path
        id="path1191"
-       d="m 368,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="850.51971"
        id="circle1193"
        style="display:inline;opacity:1;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1195"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1197"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1199"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1201"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1203"
-       cx="503"
+       cx="823"
        cy="850.51971"
        r="2" />
     <path
        sodipodi:nodetypes="cscscssssssssssss"
        inkscape:connector-curvature="0"
        id="path1205"
-       d="m 272,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1207"
-       d="m 304,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1209"
-       d="m 336,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1211"
-       d="m 336,876.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,876.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        style="display:inline;opacity:1;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 368,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1213" />
     <circle
        style="display:inline;opacity:1;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1215"
        cy="882.51971"
-       cx="368"
+       cx="688"
        r="6" />
     <path
        inkscape:connector-curvature="0"
        id="path1217"
-       d="m 400,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1219"
-       d="m 432,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1221"
-       d="m 496,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1223"
-       d="m 464.00002,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <circle
        r="2"
        cy="882.51971"
-       cx="503"
+       cx="823"
        id="circle1225"
        style="opacity:1;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 272,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
+       d="m 592,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -4,9 h 8 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -8 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 8,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z"
        id="path1227"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cscscssssssssssss" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 304,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 312 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 296 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
+       d="m 624,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 3,9 a 5,5 0 0 1 4.57617,3 H 632 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 h -0.41992 a 5,5 0 0 1 -4.58008,3 5,5 0 0 1 -4.57617,-3 H 616 a 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 h 6.41992 a 5,5 0 0 1 4.58008,-3 z m 0,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
        id="path1229"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 336,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 656,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        id="path1231"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;opacity:1;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 336,940.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
+       d="m 656,940.51971 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 z"
        id="path1233"
        inkscape:connector-curvature="0" />
     <path
        id="path1235"
-       d="m 368,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
+       d="m 688,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m 0,7 a 7,7 0 0 1 7,7 7,7 0 0 1 -7,7 7,7 0 0 1 -7,-7 7,7 0 0 1 7,-7 z"
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <circle
        r="6"
-       cx="368"
+       cx="688"
        cy="946.51971"
        id="circle1237"
        style="display:inline;opacity:1;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 400,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
+       d="m 720,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,8 h 10 v 2 h -4 v 10 h -2 v -10 h -4 z"
        id="path1239"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 432,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
+       d="m 752,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,8 h 12 c 1.108,0 2,0.892 2,2 v 8 c 0,1.108 -0.892,2 -2,2 h -12 c -1.108,0 -2,-0.892 -2,-2 v -8 c 0,-1.108 0.892,-2 2,-2 z m 4,3 v 6 l 5,-3 z"
        id="path1241"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 496,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       d="m 816,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -7,11 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m 7,0 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
        id="path1243"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 464.00002,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
+       d="m 784.00002,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -5,9 h 10 c 2.76142,0 5,2.23858 5,5 0,2.76142 -2.23858,5 -5,5 h -10 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 z m 0,1 c -2.20914,0 -4,1.79086 -4,4 0,2.20914 1.79086,4 4,4 h 4 v -8 z m 5,0 v 8 h 5 c 2.20914,0 4,-1.79086 4,-4 0,-2.20914 -1.79086,-4 -4,-4 z m 3,1 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z m -11,2 h 6 v 2 h -6 z"
        id="path1245"
        inkscape:connector-curvature="0" />
     <circle
        style="opacity:1;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="circle1247"
-       cx="503"
+       cx="823"
        cy="946.51971"
        r="2" />
     <path
        style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,740.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1266"
        inkscape:connector-curvature="0" />
     <circle
@@ -1265,51 +1265,51 @@
     <path
        inkscape:connector-curvature="0"
        id="path1289"
-       d="m 528,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,708.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        id="path1291"
-       d="m 528,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,676.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,644.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1293"
        inkscape:connector-curvature="0" />
     <path
        style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,804.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1295"
        inkscape:connector-curvature="0" />
     <path
        inkscape:connector-curvature="0"
        id="path1297"
-       d="m 528,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,772.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528.00002,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848.00002,612.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1293-5"
        inkscape:connector-curvature="0" />
     <path
        inkscape:connector-curvature="0"
        id="path1314"
-       d="m 528,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,868.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,836.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1316"
        inkscape:connector-curvature="0" />
     <path
        inkscape:connector-curvature="0"
        id="path1318"
-       d="m 528,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,932.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 528,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
+       d="m 848,900.51971 c -7.73201,-1e-5 -14,6.26799 -14,14 0,7.73201 6.268,14.00001 14,14 7.732,0 14,-6.268 14,-14 0,-7.73201 -6.268,-14 -14,-14 z m -6,10 h 12 c 2.216,0 4,1.784 4,4 0,2.216 -1.784,4 -4,4 h -12 c -2.216,0 -4,-1.784 -4,-4 0,-2.216 1.784,-4 4,-4 z m 0,1 a 3,3.0000031 0 0 0 -3,3 3,3.0000031 0 0 0 3,3 h 6 v -6 z"
        id="path1320"
        inkscape:connector-curvature="0" />
     <path
@@ -1378,5 +1378,50 @@
        id="path1124-7-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssssccccccccccccccccccccccccccccccccccccc" />
+    <path
+       id="path1124-2-6"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       d="M 272 98 C 264.268 98 258 104.268 258 112 C 258 119.73201 264.268 126 272 126 C 279.732 126 286 119.73201 286 112 C 286 104.268 279.732 98 272 98 z M 270 106 L 273 106 L 273 116 L 270 116 L 270 106 z M 275 108 L 278 108 L 278 116 L 275 116 L 275 108 z M 265 110 L 268 110 L 268 116 L 265 116 L 265 110 z M 264 117 L 279 117 L 279 118 L 264 118 L 264 117 z "
+       transform="translate(0,610.51971)" />
+    <path
+       id="path1218"
+       style="display:inline;fill:#dedede;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,676.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1220"
+       style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,644.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1222"
+       style="display:inline;fill:#444444;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,612.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1224"
+       style="display:inline;fill:#ffab7a;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,836.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1226"
+       style="display:inline;fill:#ff7c7c;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,804.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1228"
+       style="display:inline;fill:#cb90de;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,772.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1230"
+       style="display:inline;fill:#62abea;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,740.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1232"
+       style="display:inline;fill:#1ecd97;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,900.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1234"
+       style="display:inline;fill:#f7e66d;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,868.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
+    <path
+       id="path1236"
+       style="display:inline;fill:#70cbd4;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 272,932.51971 c -7.732,0 -14,6.268 -14,14 0,7.73201 6.268,14 14,14 7.732,0 14,-6.26799 14,-14 0,-7.732 -6.268,-14 -14,-14 z m -2,8 h 3 v 10 h -3 z m 5,2 h 3 v 8 h -3 z m -10,2 h 3 v 6 h -3 z m -1,7 h 15 v 1 h -15 z" />
   </g>
 </svg>

--- a/qtoggleserver/frontend/js/api/ports.js
+++ b/qtoggleserver/frontend/js/api/ports.js
@@ -11,6 +11,8 @@ import * as NotificationsAPI from './notifications.js'
 
 const ROUND_VALUE_TEMPLATE = 1e6
 
+export const HISTORY_MAX_LIMIT = 10000 /* Max number of samples downloadable with a single request */
+
 
 /**
  * GET /ports API function call.
@@ -162,4 +164,49 @@ export function patchPortSequence(id, values, delays, repeat) {
     let data = {values: values, delays: delays, repeat: repeat}
 
     return BaseAPI.apiCall({method: 'PATCH', path: `/ports/${id}/sequence`, data: data})
+}
+
+/**
+ * GET /ports/{id}/history API function call.
+ * @alias qtoggle.api.ports.getPortHistory
+ * @param {String} id the port identifier
+ * @param {Number} from start of interval, as timestamp in milliseconds
+ * @param {Number} [to] end of interval, as timestamp in milliseconds
+ * @param {Number} [limit]
+ * @returns {Promise}
+ */
+export function getPortHistory(id, from, to = null, limit = null) {
+    let query = {from}
+    if (to != null) {
+        query['to'] = to
+    }
+    if (limit != null) {
+        query['limit'] = limit
+    }
+
+    return BaseAPI.apiCall({
+        method: 'GET',
+        path: `/ports/${id}/history`,
+        query: query,
+        timeout: APIConstants.LONG_SERVER_TIMEOUT
+    })
+}
+
+/**
+ * DELETE /ports/{id}/history API function call.
+ * @alias qtoggle.api.ports.deletePortHistory
+ * @param {String} id the port identifier
+ * @param {Number} from start of interval, as timestamp in milliseconds
+ * @param {Number} to end of interval, as timestamp in milliseconds
+ * @returns {Promise}
+ */
+export function deletePortValue(id, from, to) {
+    let query = {from, to}
+
+    return BaseAPI.apiCall({
+        method: 'DELETE',
+        path: `/ports/${id}/history`,
+        query: query,
+        timeout: APIConstants.LONG_SERVER_TIMEOUT
+    })
 }

--- a/qtoggleserver/frontend/js/common/chart-page.js
+++ b/qtoggleserver/frontend/js/common/chart-page.js
@@ -1,0 +1,276 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import {gettext}             from '$qui/base/i18n.js'
+import {mix}                 from '$qui/base/mixwith.js'
+import {CheckField}          from '$qui/forms/common-fields/common-fields.js'
+import {OptionsForm}         from '$qui/forms/common-forms/common-forms.js'
+import StockIcon             from '$qui/icons/stock-icon.js'
+import {StructuredPageMixin} from '$qui/pages/common-pages/common-pages.js'
+import * as ObjectUtils      from '$qui/utils/object.js'
+import {ProgressViewMixin}   from '$qui/views/common-views/common-views.js'
+import * as Window           from '$qui/window.js'
+
+import * as Cache from '$app/cache.js'
+
+import '$app/widgets/bar-chart.js'
+import '$app/widgets/line-chart.js'
+import '$app/widgets/pie-chart.js'
+import '$app/widgets/time-chart.js'
+
+
+const MAX_DATA_POINT_LEN = 1000
+
+
+/**
+ * @alias qtoggle.common.ChartPageOptionsForm
+ * @extends qui.forms.commonforms.OptionsForm
+ */
+export class ChartPageOptionsForm extends OptionsForm {
+
+    /**
+     * @constructs
+     * @param {qtoggle.common.ChartPage} chartPage
+     * @param {Boolean} [showSmooth]
+     * @param {Boolean} [showFillArea]
+     * @param {?String} prefsPrefix
+     * @param {Object} [defaults]
+     */
+    constructor({chartPage, showSmooth = true, showFillArea = true, prefsPrefix = null, defaults = {}}) {
+        let fields = []
+        if (showSmooth) {
+            fields.push(new CheckField({
+                name: 'smooth',
+                label: gettext('Smooth Lines')
+            }))
+        }
+        if (showFillArea) {
+            fields.push(new CheckField({
+                name: 'fill_area',
+                label: gettext('Fill Area')
+            }))
+        }
+
+        let initialData = defaults
+        if (prefsPrefix) {
+            Object.assign(initialData, Cache.getPrefs(prefsPrefix, {}))
+        }
+
+        super({
+            page: chartPage,
+            fields: fields,
+            initialData: initialData
+        })
+
+        this._prefsPrefix = prefsPrefix
+    }
+
+    init() {
+        this.updateFieldsVisibility()
+        this.getData().then(data => this.getPage().updateOptions(data))
+    }
+
+    onChange(data, fieldName) {
+        if (this._prefsPrefix) {
+            Cache.setPrefs(`${this._prefsPrefix}.${fieldName}`, data[fieldName])
+        }
+
+        this.updateFieldsVisibility()
+        this.getPage().updateOptions(data)
+    }
+
+    updateFieldsVisibility() {
+    }
+
+}
+
+/**
+ * @alias qtoggle.common.ChartPage
+ * @mixes qui.pages.StructuredPageMixin
+ */
+class ChartPage extends mix().with(StructuredPageMixin, ProgressViewMixin) {
+
+    /**
+     * @constructs
+     * @param {String} type chart type
+     * @param {Object} [chartOptions] options to pass to chart widget
+     * @param {Array} [data] initial chart data
+     * @param {...*} args parent class parameters
+     */
+    constructor({type, chartOptions = {}, data = [], ...args}) {
+        ObjectUtils.assignDefault(args, {
+            popup: !Window.isSmallScreen(),
+            transparent: false,
+            closable: true,
+            icon: new StockIcon({name: 'chart', stockName: 'qtoggle'}),
+            verticallyCentered: true /* for ProgressViewMixin */
+        })
+
+        super(args)
+
+        let aspectRatio
+        if (Window.isSmallScreen()) {
+            aspectRatio = 1
+        }
+        else {
+            aspectRatio = Window.getWidth() / Window.getHeight() * 1.2
+        }
+
+        this._type = type
+        this._chartOptions = ObjectUtils.combine(chartOptions, {
+            onPanZoomStart: this.handlePanZoomStart.bind(this),
+            onPanZoomEnd: this.handlePanZoomEnd.bind(this),
+            aspectRatio: aspectRatio
+        })
+        this._data = data
+        this.widgetCall = null
+    }
+
+    initHTML(html) {
+        super.initHTML(html)
+
+        html.addClass('qtoggle-chart-page-view unexpanded')
+    }
+
+    makeBody() {
+        let chartDiv = $('<div></div>', {class: 'qtoggle-chart-page-chart-container'})
+        let widget = chartDiv[`${this._type}chart`]
+
+        this.widgetCall = function (...args) {
+            return widget.apply(chartDiv, args)
+        }
+
+        this.widgetCall(this._chartOptions)
+        this.widgetCall('setValue', this._data)
+
+        return chartDiv
+    }
+
+    makeOptionsBarContent() {
+        return new ChartPageOptionsForm({chartPage: this})
+    }
+
+    /**
+     * @param {Object} options
+     */
+    updateOptions(options) {
+        let widgetOptions = {}
+
+        if ('smooth' in options) {
+            widgetOptions.smooth = options['smooth']
+        }
+        if ('fill_area' in options) {
+            widgetOptions.fillArea = options['fill_area']
+        }
+
+        if (Object.keys(widgetOptions).length > 0) {
+            this.widgetCall(widgetOptions)
+        }
+    }
+
+    /**
+     * @param {Number} xMin
+     * @param {Number} xMax
+     * @param {Number} yMin
+     * @param {Number} yMax
+     */
+    handlePanZoomStart(xMin, xMax, yMin, yMax) {
+    }
+
+    /**
+     * @param {Number} xMin
+     * @param {Number} xMax
+     * @param {Number} yMin
+     * @param {Number} yMax
+     */
+    handlePanZoomEnd(xMin, xMax, yMin, yMax) {
+    }
+
+    /**
+     * @param {*} data
+     * @param {Boolean} [decimate]
+     */
+    setData(data, decimate = true) {
+        this._data = data
+
+        if (decimate && data.length > MAX_DATA_POINT_LEN) {
+            data = this._decimate(data)
+        }
+
+        this.widgetCall('setValue', data)
+    }
+
+    /**
+     * @returns {*}
+     */
+    getData() {
+        return this._data
+    }
+
+    _decimate(data) {
+        let windowSize = Math.round(data.length * 2 / MAX_DATA_POINT_LEN)
+        let decimatedData = []
+        for (let i = 0; i < MAX_DATA_POINT_LEN / 2; i++) {
+            let window = data.slice(i * windowSize, (i + 1) * windowSize)
+            if (!window.length) {
+                continue
+            }
+            let analysis = this._analyzeDecimationWindow(window)
+            if (analysis.min[0] < analysis.max[0]) {
+                decimatedData.push(analysis.min, analysis.max)
+            }
+            else {
+                decimatedData.push(analysis.max, analysis.min)
+            }
+        }
+
+        return decimatedData
+    }
+
+    _analyzeDecimationWindow(data) {
+        // FIXME: this only analyzes the first series in data
+        let [minX, minY] = data[0]
+        let [maxX, maxY] = data[0]
+        for (let i = 0; i < data.length; i++) {
+            let d = data[i]
+            let y = d[1]
+            if (y < minY) {
+                [minX, minY] = d
+            }
+            else if (y > maxY) {
+                [maxX, maxY] = d
+            }
+        }
+
+        return {
+            min: [minX, minY],
+            max: [maxX, maxY]
+        }
+    }
+
+    /**
+     * @returns {{min: Number, max: Number}}
+     */
+    getXRange() {
+        return this.widgetCall('getXRange')
+    }
+
+    /**
+     * @param {Number} xMin
+     * @param {Number} xMax
+     */
+    setXRange(xMin, xMax) {
+        return this.widgetCall('setXRange', xMin, xMax)
+    }
+
+    /**
+     * @returns {{min: Number, max: Number}}
+     */
+    getYRange() {
+        return this.widgetCall('getYRange')
+    }
+
+}
+
+
+export default ChartPage

--- a/qtoggleserver/frontend/js/common/history-download-manager.js
+++ b/qtoggleserver/frontend/js/common/history-download-manager.js
@@ -1,0 +1,287 @@
+
+import * as PortsAPI from '$app/api/ports.js'
+
+
+/**
+ * @alias qtoggle.common.HistoryDownloadTooManyRequests
+ * @extends Error
+ */
+export class HistoryDownloadTooManyRequests extends Error {
+}
+
+
+class Interval {
+
+    constructor(from, to, samples) {
+        this.from = from
+        this.to = to
+        this.samples = samples
+    }
+
+    isVoid() {
+        return this.from >= this.to
+    }
+
+    getSlice(from, to) {
+        if (this.to <= from) {
+            return null
+        }
+        if (this.from >= to) {
+            return null
+        }
+        if (from < this.to && this.to <= to) {
+            if (from <= this.from && this.from < to) {
+                /* This is included in range */
+                return this
+            }
+            else {
+                /* The right side of this overlaps with the left side of the range */
+                return new Interval(from, this.to, this.getSliceSamples(from, this.to))
+            }
+        }
+        else {
+            if (this.from <= from && from < this.to) {
+                /* Range is included in this */
+                return new Interval(from, to, this.getSliceSamples(from, to))
+            }
+            else {
+                /* The right side of range overlaps with the left side of this */
+                return new Interval(this.from, to, this.getSliceSamples(this.from, to))
+            }
+        }
+    }
+
+    tryMerge(interval) {
+        if (this.from < interval.to && this.to >= interval.from) {
+            let samples
+            if (this.to === interval.from) {
+                samples = this.samples.concat(interval.samples)
+            }
+            else {
+                if (interval.samples.length > 0) {
+                    samples = this.samples.filter(s => s.timestamp < interval.samples[0].timestamp)
+                    samples = samples.concat(interval.samples)
+                }
+                else {
+                    samples = this.samples
+                }
+            }
+            return new Interval(this.from, interval.to, samples)
+        }
+        else if (interval.from < this.to && interval.to >= this.from) {
+            let samples
+            if (interval.to === this.from) {
+                samples = interval.samples.concat(this.samples)
+            }
+            else {
+                if (this.samples.length > 0) {
+                    samples = interval.samples.filter(s => s.timestamp < this.samples[0].timestamp)
+                    samples = samples.concat(this.samples)
+                }
+                else {
+                    samples = interval.samples
+                }
+            }
+
+            return new Interval(interval.from, this.to, samples)
+        }
+
+        return null /* No merging possible */
+    }
+
+    getSliceSamples(from, to) {
+        if (this.samples.length === 0) {
+            return []
+        }
+
+        let slice = []
+        let i = 0
+        while (i < this.samples.length && this.samples[i].timestamp < from) {
+            i++
+        }
+        while (i < this.samples.length && this.samples[i].timestamp < to) {
+            slice.push(this.samples[i++])
+        }
+
+        return slice
+    }
+
+}
+
+
+/**
+ * @alias qtoggle.common.HistoryDownloadManager
+ */
+class HistoryDownloadManager {
+
+    /**
+     * @constructs
+     * @param {Object} port
+     */
+    constructor(port) {
+        this._port = port
+        this._intervals = []
+        this._requestCount = 0
+        this._maxRequests = 0
+    }
+
+    /**
+     * @param {Number} from
+     * @param {Number} to
+     * @param {Number} [maxRequests]
+     * @return {Promise<Object[]>}
+     */
+    fetch(from, to, maxRequests = 0) {
+        let gaps = this._findGaps(from, to)
+
+        this._requestCount = 0
+        this._maxRequests = maxRequests
+
+        /* Chain API requests for all missing intervals */
+        let promise = Promise.resolve()
+        gaps.forEach(function (gap) {
+            promise = promise.then(function () {
+                return this._downloadAndCache(gap)
+            }.bind(this))
+        }.bind(this))
+
+        return promise.then(function () {
+            return this._getCachedSamples(from, to)
+        }.bind(this))
+    }
+
+    _downloadAndCache({from, to}) {
+        return this._download({from, to}).then(function (samples) {
+
+            /* At this point, we can be sure we've got all existing samples for the requested gap */
+            this._addInterval(new Interval(from, to, samples))
+
+        }.bind(this))
+    }
+
+    _download({from, to}) {
+        if (this._maxRequests > 0 && this._requestCount >= this._maxRequests) {
+            return Promise.reject(new HistoryDownloadTooManyRequests())
+        }
+        this._requestCount++
+
+        let downloadPromise = PortsAPI.getPortHistory(this._port.id, from, to, PortsAPI.HISTORY_MAX_LIMIT)
+
+        return downloadPromise.then(function (samples) {
+
+            if (samples.length >= PortsAPI.HISTORY_MAX_LIMIT) {
+                /* If we were given a number of samples equal to the download limit, it's very likely that there's
+                 * more to be downloaded. */
+                let lastSample = samples[samples.length - 1]
+                return this._download({from: lastSample.timestamp, to}).then(function (newSamples) {
+                    return samples.concat(newSamples)
+                })
+            }
+            else {
+                return samples
+            }
+
+        }.bind(this))
+    }
+
+    _addInterval(interval) {
+        if (this._intervals.length === 0) {
+            this._intervals.push(interval)
+            return
+        }
+
+        /* Find correct position for interval */
+        let pos = 0
+        while (pos < this._intervals.length && this._intervals[pos].from < interval.from) {
+            pos++
+        }
+
+        if (pos === 0) {
+            let merged = this._intervals[0].tryMerge(interval)
+            if (merged) {
+                this._intervals[0] = merged
+            }
+            else {
+                this._intervals.splice(0, 0, interval)
+            }
+        }
+        else if (pos === this._intervals.length) {
+            let merged = this._intervals[this._intervals.length - 1].tryMerge(interval)
+            if (merged) {
+                this._intervals[this._intervals.length - 1] = merged
+            }
+            else {
+                this._intervals.push(interval)
+            }
+        }
+        else {
+            let merged = this._intervals[pos - 1].tryMerge(interval) /* Try to merge with previous interval */
+            if (merged) {
+                this._intervals[pos - 1] = merged
+            }
+            else {
+                merged = this._intervals[pos].tryMerge(interval) /* Try to merge with next interval */
+                if (merged) {
+                    this._intervals[pos] = merged
+                }
+                else {
+                    this._intervals.splice(pos, 0, interval)
+                }
+            }
+
+            /* Our new interval might have just bridged the gap between pos - 1 and pos */
+            if (merged) {
+                merged = this._intervals[pos - 1].tryMerge(this._intervals[pos])
+                if (merged) {
+                    this._intervals[pos - 1] = merged
+                    this._intervals.splice(pos, 1)
+                }
+            }
+        }
+    }
+
+    _findGaps(from, to) {
+        if (this._intervals.length === 0) {
+            return [{from, to}]
+        }
+
+        if (to <= this._intervals[0].from || from >= this._intervals[this._intervals.length - 1].to) {
+            /* Completely before the first interval or after the last one */
+            return [{from, to}]
+        }
+
+        let startPos = 0
+        while (startPos < this._intervals.length && this._intervals[startPos].from < from) {
+            startPos++
+        }
+
+        let stopPos = startPos
+        while (stopPos < this._intervals.length && this._intervals[stopPos].to < to) {
+            stopPos++
+        }
+
+        let gaps = []
+        if (startPos < this._intervals.length) {
+            if (from < this._intervals[startPos].from) {
+                gaps.push({from, to: this._intervals[startPos].from})
+            }
+            for (let pos = startPos; pos < stopPos - 1; pos++) {
+                gaps.push({from: this._intervals[pos].to, to: this._intervals[pos + 1].from})
+            }
+        }
+
+        return gaps
+    }
+
+    _getCachedSamples(from, to) {
+        /* Find all cached intervals intersections */
+        let intervals = this._intervals.map(i => i.getSlice(from, to)).filter(i => i != null)
+
+        /* Extract and merge samples */
+        return intervals.reduce((s, i) => s.concat(i.samples), [])
+    }
+
+}
+
+
+export default HistoryDownloadManager

--- a/qtoggleserver/frontend/js/dashboard/widgets/move-widget-form.js
+++ b/qtoggleserver/frontend/js/dashboard/widgets/move-widget-form.js
@@ -65,7 +65,7 @@ class MoveWidgetForm extends PageForm {
             icon: Dashboard.PANEL_ICON,
             title: title,
             pathId: 'move',
-            modal: true,
+            popup: true,
 
             fields: [
                 new PanelPickerField({

--- a/qtoggleserver/frontend/js/dashboard/widgets/widget.js
+++ b/qtoggleserver/frontend/js/dashboard/widgets/widget.js
@@ -15,7 +15,6 @@ import * as Gestures        from '$qui/utils/gestures.js'
 import {asap}               from '$qui/utils/misc.js'
 import * as StringUtils     from '$qui/utils/string.js'
 import ViewMixin            from '$qui/views/view.js'
-import * as Window          from '$qui/window.js'
 
 import * as AuthAPI  from '$app/api/auth.js'
 import * as PortsAPI from '$app/api/ports.js'

--- a/qtoggleserver/frontend/js/lib/chartjs-plugin-zoom.js
+++ b/qtoggleserver/frontend/js/lib/chartjs-plugin-zoom.js
@@ -1,0 +1,682 @@
+/* eslint-disable */
+'use strict';
+
+import * as ChartJS from '$app/lib/chartjs.module.js';
+import Hammer from '$app/lib/hammer.module.js';
+
+var Chart = ChartJS.Chart;
+var helpers = ChartJS;
+
+// Take the zoom namespace of Chart
+var zoomNS = Chart.Zoom = Chart.Zoom || {};
+
+// Where we store functions to handle different scale types
+var zoomFunctions = zoomNS.zoomFunctions = zoomNS.zoomFunctions || {};
+var panFunctions = zoomNS.panFunctions = zoomNS.panFunctions || {};
+
+function resolveOptions(chart, options) {
+	var deprecatedOptions = {};
+	if (typeof chart.options.pan !== 'undefined') {
+		deprecatedOptions.pan = chart.options.pan;
+	}
+	if (typeof chart.options.zoom !== 'undefined') {
+		deprecatedOptions.zoom = chart.options.zoom;
+	}
+	var props = chart.$zoom;
+	options = props._options = helpers.merge({}, [options, deprecatedOptions]);
+
+	// Install listeners. Do this dynamically based on options so that we can turn zoom on and off
+	// We also want to make sure listeners aren't always on. E.g. if you're scrolling down a page
+	// and the mouse goes over a chart you don't want it intercepted unless the plugin is enabled
+	var node = props._node;
+	var zoomEnabled = options.zoom && options.zoom.enabled;
+	var dragEnabled = options.zoom.drag;
+	if (zoomEnabled && !dragEnabled) {
+		node.addEventListener('wheel', props._wheelHandler);
+	} else {
+		node.removeEventListener('wheel', props._wheelHandler);
+	}
+	if (zoomEnabled && dragEnabled) {
+		node.addEventListener('mousedown', props._mouseDownHandler);
+		node.ownerDocument.addEventListener('mouseup', props._mouseUpHandler);
+	} else {
+		node.removeEventListener('mousedown', props._mouseDownHandler);
+		node.removeEventListener('mousemove', props._mouseMoveHandler);
+		node.ownerDocument.removeEventListener('mouseup', props._mouseUpHandler);
+	}
+}
+
+function storeOriginalOptions(chart) {
+	var originalOptions = chart.$zoom._originalOptions;
+	helpers.each(chart.scales, function(scale) {
+		if (!originalOptions[scale.id]) {
+			originalOptions[scale.id] = helpers.clone(scale.options);
+		}
+	});
+	helpers.each(originalOptions, function(opt, key) {
+		if (!chart.scales[key]) {
+			delete originalOptions[key];
+		}
+	});
+}
+
+/**
+ * @param {string} mode can be 'x', 'y' or 'xy'
+ * @param {string} dir can be 'x' or 'y'
+ * @param {Chart} chart instance of the chart in question
+ */
+function directionEnabled(mode, dir, chart) {
+	if (mode === undefined) {
+		return true;
+	} else if (typeof mode === 'string') {
+		return mode.indexOf(dir) !== -1;
+	} else if (typeof mode === 'function') {
+		return mode({chart: chart}).indexOf(dir) !== -1;
+	}
+
+	return false;
+}
+
+function rangeMaxLimiter(zoomPanOptions, newMax) {
+	if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMax &&
+			!helpers.isNullOrUndef(zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes])) {
+		var rangeMax = zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes];
+		if (newMax > rangeMax) {
+			newMax = rangeMax;
+		}
+	}
+	return newMax;
+}
+
+function rangeMinLimiter(zoomPanOptions, newMin) {
+	if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMin &&
+			!helpers.isNullOrUndef(zoomPanOptions.rangeMin[zoomPanOptions.scaleAxes])) {
+		var rangeMin = zoomPanOptions.rangeMin[zoomPanOptions.scaleAxes];
+		if (newMin < rangeMin) {
+			newMin = rangeMin;
+		}
+	}
+	return newMin;
+}
+
+function zoomCategoryScale(scale, zoom, center, zoomOptions) {
+	var labels = scale.chart.data.labels;
+	var minIndex = scale.min;
+	var lastLabelIndex = labels.length - 1;
+	var maxIndex = scale.max;
+	var sensitivity = zoomOptions.sensitivity;
+	var chartCenter = scale.isHorizontal() ? scale.left + (scale.width / 2) : scale.top + (scale.height / 2);
+	var centerPointer = scale.isHorizontal() ? center.x : center.y;
+
+	zoomNS.zoomCumulativeDelta = zoom > 1 ? zoomNS.zoomCumulativeDelta + 1 : zoomNS.zoomCumulativeDelta - 1;
+
+	if (Math.abs(zoomNS.zoomCumulativeDelta) > sensitivity) {
+		if (zoomNS.zoomCumulativeDelta < 0) {
+			if (centerPointer >= chartCenter) {
+				if (minIndex <= 0) {
+					maxIndex = Math.min(lastLabelIndex, maxIndex + 1);
+				} else {
+					minIndex = Math.max(0, minIndex - 1);
+				}
+			} else if (centerPointer < chartCenter) {
+				if (maxIndex >= lastLabelIndex) {
+					minIndex = Math.max(0, minIndex - 1);
+				} else {
+					maxIndex = Math.min(lastLabelIndex, maxIndex + 1);
+				}
+			}
+			zoomNS.zoomCumulativeDelta = 0;
+		} else if (zoomNS.zoomCumulativeDelta > 0) {
+			if (centerPointer >= chartCenter) {
+				minIndex = minIndex < maxIndex ? minIndex = Math.min(maxIndex, minIndex + 1) : minIndex;
+			} else if (centerPointer < chartCenter) {
+				maxIndex = maxIndex > minIndex ? maxIndex = Math.max(minIndex, maxIndex - 1) : maxIndex;
+			}
+			zoomNS.zoomCumulativeDelta = 0;
+		}
+		scale.options.min = rangeMinLimiter(zoomOptions, labels[minIndex]);
+		scale.options.max = rangeMaxLimiter(zoomOptions, labels[maxIndex]);
+	}
+}
+
+function zoomNumericalScale(scale, zoom, center, zoomOptions) {
+	var range = scale.max - scale.min;
+	var newDiff = range * (zoom - 1);
+
+	var centerPoint = scale.isHorizontal() ? center.x : center.y;
+	var minPercent = (scale.getValueForPixel(centerPoint) - scale.min) / range;
+	var maxPercent = 1 - minPercent;
+
+	var minDelta = newDiff * minPercent;
+	var maxDelta = newDiff * maxPercent;
+
+	scale.options.min = rangeMinLimiter(zoomOptions, scale.min + minDelta);
+	scale.options.max = rangeMaxLimiter(zoomOptions, scale.max - maxDelta);
+}
+
+function zoomScale(scale, zoom, center, zoomOptions) {
+	var fn = zoomFunctions[scale.type];
+	if (fn) {
+		fn(scale, zoom, center, zoomOptions);
+	}
+}
+
+/**
+ * @param chart The chart instance
+ * @param {number} percentZoomX The zoom percentage in the x direction
+ * @param {number} percentZoomY The zoom percentage in the y direction
+ * @param {{x: number, y: number}} focalPoint The x and y coordinates of zoom focal point. The point which doesn't change while zooming. E.g. the location of the mouse cursor when "drag: false"
+ * @param {string} whichAxes `xy`, 'x', or 'y'
+ * @param {number} animationDuration Duration of the animation of the redraw in milliseconds
+ */
+function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, animationDuration) {
+	var ca = chart.chartArea;
+	if (!focalPoint) {
+		focalPoint = {
+			x: (ca.left + ca.right) / 2,
+			y: (ca.top + ca.bottom) / 2,
+		};
+	}
+
+	var zoomOptions = chart.$zoom._options.zoom;
+
+	if (zoomOptions.enabled) {
+		storeOriginalOptions(chart);
+		// Do the zoom here
+		var zoomMode = typeof zoomOptions.mode === 'function' ? zoomOptions.mode({chart: chart}) : zoomOptions.mode;
+
+		// Which axe should be modified when figers were used.
+		var _whichAxes;
+		if (zoomMode === 'xy' && whichAxes !== undefined) {
+			// based on fingers positions
+			_whichAxes = whichAxes;
+		} else {
+			// no effect
+			_whichAxes = 'xy';
+		}
+
+		helpers.each(chart.scales, function(scale) {
+			if (scale.isHorizontal() && directionEnabled(zoomMode, 'x', chart) && directionEnabled(_whichAxes, 'x', chart)) {
+				zoomOptions.scaleAxes = 'x';
+				zoomScale(scale, percentZoomX, focalPoint, zoomOptions);
+			} else if (!scale.isHorizontal() && directionEnabled(zoomMode, 'y', chart) && directionEnabled(_whichAxes, 'y', chart)) {
+				// Do Y zoom
+				zoomOptions.scaleAxes = 'y';
+				zoomScale(scale, percentZoomY, focalPoint, zoomOptions);
+			}
+		});
+
+		if (animationDuration) {
+			// needs to create specific animation mode
+			if (!chart.options.animation.zoom) {
+				chart.options.animation.zoom = {
+					duration: animationDuration,
+					easing: 'easeOutQuad',
+				};
+			}
+			chart.update('zoom');
+		} else {
+			chart.update('none');
+		}
+
+		if (typeof zoomOptions.onZoom === 'function') {
+			zoomOptions.onZoom({chart: chart});
+		}
+	}
+}
+
+function panCategoryScale(scale, delta, panOptions) {
+	var labels = scale.chart.data.labels;
+	var lastLabelIndex = labels.length - 1;
+	var offsetAmt = Math.max(scale.ticks.length, 1);
+	var panSpeed = panOptions.speed;
+	var minIndex = scale.min;
+	var step = Math.round(scale.width / (offsetAmt * panSpeed));
+	var maxIndex;
+
+	zoomNS.panCumulativeDelta += delta;
+
+	minIndex = zoomNS.panCumulativeDelta > step ? Math.max(0, minIndex - 1) : zoomNS.panCumulativeDelta < -step ? Math.min(lastLabelIndex - offsetAmt + 1, minIndex + 1) : minIndex;
+	zoomNS.panCumulativeDelta = minIndex !== scale.min ? 0 : zoomNS.panCumulativeDelta;
+
+	maxIndex = Math.min(lastLabelIndex, minIndex + offsetAmt - 1);
+
+	scale.options.min = rangeMinLimiter(panOptions, labels[minIndex]);
+	scale.options.max = rangeMaxLimiter(panOptions, labels[maxIndex]);
+}
+
+function panNumericalScale(scale, delta, panOptions) {
+	var scaleOpts = scale.options;
+	var prevStart = scale.min;
+	var prevEnd = scale.max;
+	var newMin = scale.getValueForPixel(scale.getPixelForValue(prevStart) - delta);
+	var newMax = scale.getValueForPixel(scale.getPixelForValue(prevEnd) - delta);
+	var rangeMin = newMin;
+	var rangeMax = newMax;
+	var diff;
+
+	if (panOptions.scaleAxes && panOptions.rangeMin &&
+			!helpers.isNullOrUndef(panOptions.rangeMin[panOptions.scaleAxes])) {
+		rangeMin = panOptions.rangeMin[panOptions.scaleAxes];
+	}
+	if (panOptions.scaleAxes && panOptions.rangeMax &&
+			!helpers.isNullOrUndef(panOptions.rangeMax[panOptions.scaleAxes])) {
+		rangeMax = panOptions.rangeMax[panOptions.scaleAxes];
+	}
+
+	if (newMin >= rangeMin && newMax <= rangeMax) {
+		scaleOpts.min = newMin;
+		scaleOpts.max = newMax;
+	} else if (newMin < rangeMin) {
+		diff = prevStart - rangeMin;
+		scaleOpts.min = rangeMin;
+		scaleOpts.max = prevEnd - diff;
+	} else if (newMax > rangeMax) {
+		diff = rangeMax - prevEnd;
+		scaleOpts.max = rangeMax;
+		scaleOpts.min = prevStart + diff;
+	}
+}
+
+function panScale(scale, delta, panOptions) {
+	var fn = panFunctions[scale.type];
+	if (fn) {
+		fn(scale, delta, panOptions);
+	}
+}
+
+function doPan(chartInstance, deltaX, deltaY) {
+	storeOriginalOptions(chartInstance);
+	var panOptions = chartInstance.$zoom._options.pan;
+	if (panOptions.enabled) {
+		var panMode = typeof panOptions.mode === 'function' ? panOptions.mode({chart: chartInstance}) : panOptions.mode;
+
+		helpers.each(chartInstance.scales, function(scale) {
+			if (scale.isHorizontal() && directionEnabled(panMode, 'x', chartInstance) && deltaX !== 0) {
+				panOptions.scaleAxes = 'x';
+				panScale(scale, deltaX, panOptions);
+			} else if (!scale.isHorizontal() && directionEnabled(panMode, 'y', chartInstance) && deltaY !== 0) {
+				panOptions.scaleAxes = 'y';
+				panScale(scale, deltaY, panOptions);
+			}
+		});
+
+		chartInstance.update('none');
+
+		if (typeof panOptions.onPan === 'function') {
+			panOptions.onPan({chart: chartInstance});
+		}
+	}
+}
+
+function getXAxis(chartInstance) {
+	var scales = chartInstance.scales;
+	var scaleIds = Object.keys(scales);
+	for (var i = 0; i < scaleIds.length; i++) {
+		var scale = scales[scaleIds[i]];
+
+		if (scale.isHorizontal()) {
+			return scale;
+		}
+	}
+}
+
+function getYAxis(chartInstance) {
+	var scales = chartInstance.scales;
+	var scaleIds = Object.keys(scales);
+	for (var i = 0; i < scaleIds.length; i++) {
+		var scale = scales[scaleIds[i]];
+
+		if (!scale.isHorizontal()) {
+			return scale;
+		}
+	}
+}
+
+// Store these for later
+zoomNS.zoomFunctions.category = zoomCategoryScale;
+zoomNS.zoomFunctions.time = zoomNumericalScale;
+zoomNS.zoomFunctions.linear = zoomNumericalScale;
+zoomNS.zoomFunctions.logarithmic = zoomNumericalScale;
+zoomNS.panFunctions.category = panCategoryScale;
+zoomNS.panFunctions.time = panNumericalScale;
+zoomNS.panFunctions.linear = panNumericalScale;
+zoomNS.panFunctions.logarithmic = panNumericalScale;
+// Globals for category pan and zoom
+zoomNS.panCumulativeDelta = 0;
+zoomNS.zoomCumulativeDelta = 0;
+
+// Chartjs Zoom Plugin
+var zoomPlugin = {
+	id: 'zoom',
+
+	defaults: {
+		pan: {
+			enabled: false,
+			mode: 'xy',
+			speed: 20,
+			threshold: 10
+		},
+		zoom: {
+			enabled: false,
+			mode: 'xy',
+			sensitivity: 3,
+			speed: 0.1
+		}
+	},
+
+	afterInit: function(chartInstance) {
+
+		chartInstance.resetZoom = function() {
+			storeOriginalOptions(chartInstance);
+			var originalOptions = chartInstance.$zoom._originalOptions;
+			helpers.each(chartInstance.scales, function(scale) {
+
+				var options = scale.options;
+				if (originalOptions[scale.id]) {
+					options.min = originalOptions[scale.id].min;
+					options.max = originalOptions[scale.id].max;
+				} else {
+					delete options.min;
+					delete options.max;
+				}
+			});
+			chartInstance.update();
+		};
+
+	},
+
+	beforeUpdate: function(chart, args, options) {
+		resolveOptions(chart, options);
+	},
+
+	beforeInit: function(chartInstance, args, pluginOptions) {
+		chartInstance.$zoom = {
+			_originalOptions: {}
+		};
+		var node = chartInstance.$zoom._node = chartInstance.ctx.canvas;
+		resolveOptions(chartInstance, pluginOptions);
+
+		var options = chartInstance.$zoom._options;
+		var panThreshold = options.pan && options.pan.threshold;
+
+		chartInstance.$zoom._mouseDownHandler = function(event) {
+			node.addEventListener('mousemove', chartInstance.$zoom._mouseMoveHandler);
+			chartInstance.$zoom._dragZoomStart = event;
+		};
+
+		chartInstance.$zoom._mouseMoveHandler = function(event) {
+			if (chartInstance.$zoom._dragZoomStart) {
+				chartInstance.$zoom._dragZoomEnd = event;
+				chartInstance.update('none');
+			}
+		};
+
+		chartInstance.$zoom._mouseUpHandler = function(event) {
+			if (!chartInstance.$zoom._dragZoomStart) {
+				return;
+			}
+
+			node.removeEventListener('mousemove', chartInstance.$zoom._mouseMoveHandler);
+
+			var beginPoint = chartInstance.$zoom._dragZoomStart;
+
+			var offsetX = beginPoint.target.getBoundingClientRect().left;
+			var startX = Math.min(beginPoint.clientX, event.clientX) - offsetX;
+			var endX = Math.max(beginPoint.clientX, event.clientX) - offsetX;
+
+			var offsetY = beginPoint.target.getBoundingClientRect().top;
+			var startY = Math.min(beginPoint.clientY, event.clientY) - offsetY;
+			var endY = Math.max(beginPoint.clientY, event.clientY) - offsetY;
+
+			var dragDistanceX = endX - startX;
+			var dragDistanceY = endY - startY;
+
+			// Remove drag start and end before chart update to stop drawing selected area
+			chartInstance.$zoom._dragZoomStart = null;
+			chartInstance.$zoom._dragZoomEnd = null;
+
+			var zoomThreshold = (options.zoom && options.zoom.threshold) || 0;
+			if (dragDistanceX <= zoomThreshold && dragDistanceY <= zoomThreshold) {
+				return;
+			}
+
+			var chartArea = chartInstance.chartArea;
+
+			var zoomOptions = chartInstance.$zoom._options.zoom;
+			var chartDistanceX = chartArea.right - chartArea.left;
+			var xEnabled = directionEnabled(zoomOptions.mode, 'x', chartInstance);
+			var zoomX = xEnabled && dragDistanceX ? 1 + ((chartDistanceX - dragDistanceX) / chartDistanceX) : 1;
+
+			var chartDistanceY = chartArea.bottom - chartArea.top;
+			var yEnabled = directionEnabled(zoomOptions.mode, 'y', chartInstance);
+			var zoomY = yEnabled && dragDistanceY ? 1 + ((chartDistanceY - dragDistanceY) / chartDistanceY) : 1;
+
+			doZoom(chartInstance, zoomX, zoomY, {
+				x: (startX - chartArea.left) / (1 - dragDistanceX / chartDistanceX) + chartArea.left,
+				y: (startY - chartArea.top) / (1 - dragDistanceY / chartDistanceY) + chartArea.top
+			}, undefined, zoomOptions.drag.animationDuration);
+
+			if (typeof zoomOptions.onZoomComplete === 'function') {
+				zoomOptions.onZoomComplete({chart: chartInstance});
+			}
+		};
+
+		var _scrollTimeout = null;
+		chartInstance.$zoom._wheelHandler = function(event) {
+			// Prevent the event from triggering the default behavior (eg. Content scrolling).
+			if (event.cancelable) {
+				event.preventDefault();
+			}
+
+			// Firefox always fires the wheel event twice:
+			// First without the delta and right after that once with the delta properties.
+			if (typeof event.deltaY === 'undefined') {
+				return;
+			}
+
+			var rect = event.target.getBoundingClientRect();
+			var offsetX = event.clientX - rect.left;
+			var offsetY = event.clientY - rect.top;
+
+			var center = {
+				x: offsetX,
+				y: offsetY
+			};
+
+			var zoomOptions = chartInstance.$zoom._options.zoom;
+			var speedPercent = zoomOptions.speed;
+
+			if (event.deltaY >= 0) {
+				speedPercent = -speedPercent;
+			}
+			doZoom(chartInstance, 1 + speedPercent, 1 + speedPercent, center);
+
+			clearTimeout(_scrollTimeout);
+			_scrollTimeout = setTimeout(function() {
+				if (typeof zoomOptions.onZoomComplete === 'function') {
+					zoomOptions.onZoomComplete({chart: chartInstance});
+				}
+			}, 250);
+		};
+
+		if (Hammer) {
+			var mc = new Hammer.Manager(node);
+			mc.add(new Hammer.Pinch());
+			mc.add(new Hammer.Pan({
+				threshold: panThreshold
+			}));
+
+			// Hammer reports the total scaling. We need the incremental amount
+			var currentPinchScaling;
+			var handlePinch = function(e) {
+				var diff = 1 / (currentPinchScaling) * e.scale;
+				var rect = e.target.getBoundingClientRect();
+				var offsetX = e.center.x - rect.left;
+				var offsetY = e.center.y - rect.top;
+				var center = {
+					x: offsetX,
+					y: offsetY
+				};
+
+				// fingers position difference
+				var x = Math.abs(e.pointers[0].clientX - e.pointers[1].clientX);
+				var y = Math.abs(e.pointers[0].clientY - e.pointers[1].clientY);
+
+				// diagonal fingers will change both (xy) axes
+				var p = x / y;
+				var xy;
+				if (p > 0.3 && p < 1.7) {
+					xy = 'xy';
+				} else if (x > y) {
+					xy = 'x'; // x axis
+				} else {
+					xy = 'y'; // y axis
+				}
+
+				doZoom(chartInstance, diff, diff, center, xy);
+
+				var zoomOptions = chartInstance.$zoom._options.zoom;
+				if (typeof zoomOptions.onZoom === 'function') {
+					zoomOptions.onZoom({chart: chartInstance});
+				}
+
+				// Keep track of overall scale
+				currentPinchScaling = e.scale;
+			};
+
+			mc.on('pinchstart', function() {
+				currentPinchScaling = 1; // reset tracker
+			});
+			mc.on('pinch', handlePinch);
+			mc.on('pinchend', function(e) {
+				handlePinch(e);
+				currentPinchScaling = null; // reset
+				zoomNS.zoomCumulativeDelta = 0;
+
+				var zoomOptions = chartInstance.$zoom._options.zoom;
+				if (typeof zoomOptions.onZoomComplete === 'function') {
+					zoomOptions.onZoomComplete({chart: chartInstance});
+				}
+			});
+
+			var currentDeltaX = null;
+			var currentDeltaY = null;
+			var panning = false;
+			var handlePan = function(e) {
+				if (currentDeltaX !== null && currentDeltaY !== null) {
+					panning = true;
+					var deltaX = e.deltaX - currentDeltaX;
+					var deltaY = e.deltaY - currentDeltaY;
+					currentDeltaX = e.deltaX;
+					currentDeltaY = e.deltaY;
+					doPan(chartInstance, deltaX, deltaY);
+				}
+			};
+
+			mc.on('panstart', function(e) {
+				currentDeltaX = 0;
+				currentDeltaY = 0;
+				handlePan(e);
+			});
+			mc.on('panmove', handlePan);
+			mc.on('panend', function() {
+				currentDeltaX = null;
+				currentDeltaY = null;
+				zoomNS.panCumulativeDelta = 0;
+				setTimeout(function() {
+					panning = false;
+				}, 500);
+
+				var panOptions = chartInstance.$zoom._options.pan;
+				if (typeof panOptions.onPanComplete === 'function') {
+					panOptions.onPanComplete({chart: chartInstance});
+				}
+			});
+
+			chartInstance.$zoom._ghostClickHandler = function(e) {
+				if (panning && e.cancelable) {
+					e.stopImmediatePropagation();
+					e.preventDefault();
+				}
+			};
+			node.addEventListener('click', chartInstance.$zoom._ghostClickHandler);
+
+			chartInstance._mc = mc;
+		}
+	},
+
+	beforeDatasetsDraw: function(chartInstance) {
+		var ctx = chartInstance.ctx;
+
+		if (chartInstance.$zoom._dragZoomEnd) {
+			var xAxis = getXAxis(chartInstance);
+			var yAxis = getYAxis(chartInstance);
+			var beginPoint = chartInstance.$zoom._dragZoomStart;
+			var endPoint = chartInstance.$zoom._dragZoomEnd;
+
+			var startX = xAxis.left;
+			var endX = xAxis.right;
+			var startY = yAxis.top;
+			var endY = yAxis.bottom;
+
+			if (directionEnabled(chartInstance.$zoom._options.zoom.mode, 'x', chartInstance)) {
+				var offsetX = beginPoint.target.getBoundingClientRect().left;
+				startX = Math.min(beginPoint.clientX, endPoint.clientX) - offsetX;
+				endX = Math.max(beginPoint.clientX, endPoint.clientX) - offsetX;
+			}
+
+			if (directionEnabled(chartInstance.$zoom._options.zoom.mode, 'y', chartInstance)) {
+				var offsetY = beginPoint.target.getBoundingClientRect().top;
+				startY = Math.min(beginPoint.clientY, endPoint.clientY) - offsetY;
+				endY = Math.max(beginPoint.clientY, endPoint.clientY) - offsetY;
+			}
+
+			var rectWidth = endX - startX;
+			var rectHeight = endY - startY;
+			var dragOptions = chartInstance.$zoom._options.zoom.drag;
+
+			ctx.save();
+			ctx.beginPath();
+			ctx.fillStyle = dragOptions.backgroundColor || 'rgba(225,225,225,0.3)';
+			ctx.fillRect(startX, startY, rectWidth, rectHeight);
+
+			if (dragOptions.borderWidth > 0) {
+				ctx.lineWidth = dragOptions.borderWidth;
+				ctx.strokeStyle = dragOptions.borderColor || 'rgba(225,225,225)';
+				ctx.strokeRect(startX, startY, rectWidth, rectHeight);
+			}
+			ctx.restore();
+		}
+	},
+
+	destroy: function(chartInstance) {
+		if (!chartInstance.$zoom) {
+			return;
+		}
+		var props = chartInstance.$zoom;
+		var node = props._node;
+
+		node.removeEventListener('mousedown', props._mouseDownHandler);
+		node.removeEventListener('mousemove', props._mouseMoveHandler);
+		node.ownerDocument.removeEventListener('mouseup', props._mouseUpHandler);
+		node.removeEventListener('wheel', props._wheelHandler);
+		node.removeEventListener('click', props._ghostClickHandler);
+
+		delete chartInstance.$zoom;
+
+		var mc = chartInstance._mc;
+		if (mc) {
+			mc.remove('pinchstart');
+			mc.remove('pinch');
+			mc.remove('pinchend');
+			mc.remove('panstart');
+			mc.remove('pan');
+			mc.remove('panend');
+			mc.destroy();
+		}
+	}
+};
+
+Chart.register(zoomPlugin);
+export default zoomPlugin;

--- a/qtoggleserver/frontend/js/lib/chartjs.module.js
+++ b/qtoggleserver/frontend/js/lib/chartjs.module.js
@@ -1,0 +1,29 @@
+
+import * as ChartJS from '$node/chart.js/dist/chart.esm.js'
+
+window['chart.js'] = ChartJS
+
+export * from '$node/chart.js/dist/chart.esm.js'
+
+/* Hack to allow plugins such as zoom to access Chart.js helpers.
+ * This needs to be manually updated each time we upgrade chart.js version.
+ * The first part of exports is separately added as it is not found among the imports in chart.esm.js. */
+
+export {
+    ar as clone,
+
+    r as requestAnimFrame, a as resolve, e as effects, c as color, i as isObject, d as defaults, n as noop,
+    v as valueOrDefault, u as unlistenArrayEvents, l as listenArrayEvents, m as merge, b as isArray,
+    f as resolveObjectKey, g as getHoverColor, _ as _capitalize, h as mergeIf, s as sign, j as _merger,
+    k as isNullOrUndef, o as clipArea, p as unclipArea, q as _arrayUnique, t as toRadians, T as TAU, H as HALF_PI,
+    P as PI, w as isNumber, x as _limitValue, y as _lookupByKey, z as getRelativePosition$1, A as _isPointInArea,
+    B as _rlookupByKey, C as toPadding, D as each, E as getMaximumSize, F as _getParentNode, G as readUsedSize,
+    I as throttled, J as supportsEventListenerOptions, K as log10, L as finiteOrDefault, M as isNumberFinite,
+    N as callback, O as toDegrees, Q as _measureText, R as _int16Range, S as _alignPixel, U as toFont, V as _factorize,
+    W as uid, X as retinaScale, Y as clear, Z as _elementsEqual, $ as getAngleFromPoint, a0 as _angleBetween,
+    a1 as _updateBezierControlPoints, a2 as _computeSegments, a3 as _boundSegments, a4 as _steppedInterpolation,
+    a5 as _bezierInterpolation, a6 as _pointInLine, a7 as _steppedLineTo, a8 as _bezierCurveTo, a9 as drawPoint,
+    aa as toTRBL, ab as toTRBLCorners, ac as _normalizeAngle, ad as _boundSegment, ae as INFINITY, af as getRtlAdapter,
+    ag as overrideTextDirection, ah as restoreTextDirection, ai as distanceBetweenPoints, aj as _setMinAndMaxByKey,
+    ak as _decimalPlaces, al as almostEquals, am as almostWhole, an as _longestText, ao as _filterBetween, ap as _lookup
+} from '$node/chart.js/dist/chunks/helpers.segment.js'

--- a/qtoggleserver/frontend/js/lib/hammer.module.js
+++ b/qtoggleserver/frontend/js/lib/hammer.module.js
@@ -1,0 +1,4 @@
+
+import '$node/hammerjs/hammer.min.js'
+
+export default window.Hammer

--- a/qtoggleserver/frontend/js/ports/port-history-chart-page.js
+++ b/qtoggleserver/frontend/js/ports/port-history-chart-page.js
@@ -1,0 +1,226 @@
+
+import $      from '$qui/lib/jquery.module.js'
+import Logger from '$qui/lib/logger.module.js'
+
+import {gettext}        from '$qui/base/i18n.js'
+import * as Toast       from '$qui/messages/toast.js'
+import * as StringUtils from '$qui/utils/string.js'
+
+import ChartPage                        from '$app/common/chart-page.js'
+import {ChartPageOptionsForm}           from '$app/common/chart-page.js'
+import HistoryDownloadManager           from '$app/common/history-download-manager.js'
+import {HistoryDownloadTooManyRequests} from '$app/common/history-download-manager.js'
+
+
+const logger = Logger.get('qtoggle.common.porthistorychartpage')
+
+const INITIAL_INTERVAL = 24 * 3600 * 1000 /* Last 24h */
+const MAX_FETCH_REQUESTS = 5 /* This translates into at most 50k data points in an interval */
+const TIME_WINDOW_CHOICES = [
+    {label: gettext('1m|1 minute'), value: 60},
+    {label: gettext('10m|10 minutes'), value: 600},
+    {label: gettext('1h|1 hour'), value: 3600},
+    {label: gettext('1d|1 day'), value: 3600 * 24},
+    {label: gettext('1w|1 week'), value: 3600 * 24 * 7},
+    {label: gettext('1M|1 month'), value: 3600 * 24 * 31},
+    {label: gettext('1Y|1 year'), value: 3600 * 24 * 366},
+    {label: gettext('10Y|10 years'), value: 3600 * 24 * 3652}
+]
+
+
+class PortHistoryChartPageOptionsForm extends ChartPageOptionsForm {
+}
+
+
+/**
+ * @alias qtoggle.ports.PortHistoryChart
+ * @extends qtoggle.common.ChartPage
+ */
+class PortHistoryChartPage extends ChartPage {
+
+    /**
+     * @constructs
+     * @param {Object} port
+     */
+    constructor(port) {
+        let displayName = port['display_name'] || port['id']
+        let now = new Date().getTime()
+        let from = now - INITIAL_INTERVAL
+        let isBoolean = port['type'] === 'boolean'
+
+        super({
+            title: StringUtils.formatPercent(gettext('%(port)s History'), {port: displayName}),
+            type: 'time',
+            pathId: 'history',
+            chartOptions: {
+                showTooltips: true,
+                showPoints: null,
+                showMajorTicks: true,
+                yTicksStepSize: isBoolean ? 1 : null,
+                yTicksLabelCallback: isBoolean ? value => value ? gettext('On') : gettext('Off') : null,
+                panZoomMode: 'x',
+                panZoomXMax: now,
+                xMin: from,
+                xMax: now,
+                unitOfMeasurement: port['unit'],
+                stepped: isBoolean
+            }
+        })
+
+        this._port = port
+        this._isBoolean = isBoolean
+        this._historyDownloadManager = new HistoryDownloadManager(port)
+        this._timeWindowChoiceButtons = null
+        this._prevButton = null
+        this._nextButton = null
+    }
+
+    load() {
+        let {min: from, max: to} = this.getXRange()
+        this.chartToTimeWindow()
+        return this.fetchAndShowHistory(from, to)
+    }
+
+    handlePanZoomEnd(xMin, xMax, yMin, yMax) {
+        this.chartToTimeWindow()
+        this.fetchAndShowHistory(/* from = */ xMin, /* to = */ xMax)
+    }
+
+    fetchAndShowHistory(from, to) {
+        let delta = to - from
+        let margin = delta * 0.1 /* 10% margin to the left as well as to the right of the interval */
+        to += margin
+        from -= margin
+
+        this.setProgress()
+
+        let fetchPromise = this._historyDownloadManager.fetch(Math.round(from), Math.round(to), MAX_FETCH_REQUESTS)
+        return fetchPromise.then(function (history) {
+
+            this.clearProgress()
+            this.showHistory(history)
+
+        }.bind(this)).catch(function (e) {
+
+            if (e instanceof HistoryDownloadTooManyRequests) {
+                let msg = gettext('Please choose a smaller interval of time!')
+                Toast.error(msg)
+                logger.warn('too many requests while downloading history')
+                this.clearProgress()
+            }
+            else {
+                logger.errorStack('history load failed', e)
+                this.setError(e)
+            }
+
+        }.bind(this))
+    }
+
+    showHistory(history) {
+        let data
+        if (this._isBoolean) {
+            data = history.map(sample => [sample.timestamp, sample.value ? 1 : 0])
+        }
+        else {
+            data = history.map(sample => [sample.timestamp, sample.value])
+        }
+
+        this.setData(data)
+    }
+
+    makeBottom() {
+        let bottomDiv = $('<div></div>', {class: 'ports-history-chart-page-bottom'})
+
+        bottomDiv.append(this.makeNavigationDiv())
+
+        return bottomDiv
+    }
+
+    makeNavigationDiv() {
+        let navigDiv = $('<div></div>', {class: 'ports-history-chart-page-navigation'})
+
+        let choices = TIME_WINDOW_CHOICES
+        choices = choices.map(c => ({label: c.label.split('|'), value: c.value}))
+        choices = choices.map(c => ({label: c.label[0], description: c.label[1], value: c.value}))
+
+        this._timeWindowChoiceButtons = $('<div></div>', {class: 'ports-history-chart-time-window-choice-buttons'})
+        this._timeWindowChoiceButtons.choicebuttons({
+            choices: choices
+        })
+        this._timeWindowChoiceButtons.on('change', this.timeWindowToChart.bind(this))
+
+        this._prevButton = $('<div></div>', {class: 'ports-history-chart-button ports-history-chart-prev-button'})
+        this._nextButton = $('<div></div>', {class: 'ports-history-chart-button ports-history-chart-next-button'})
+
+        this._prevButton.pushbutton({
+            caption: '&#x25C0;'
+        })
+        this._prevButton.on('click', this.showPrevTimeWindow.bind(this))
+
+        this._nextButton.pushbutton({
+            caption: '&#x25B6;'
+        })
+        this._nextButton.on('click', this.showNextTimeWindow.bind(this))
+
+        navigDiv.append(this._prevButton)
+        navigDiv.append(this._timeWindowChoiceButtons)
+        navigDiv.append(this._nextButton)
+
+        return navigDiv
+    }
+
+    chartToTimeWindow() {
+        let {min, max} = this.getXRange()
+        let deltaSeconds = (max - min + 1) / 1000
+        let value = null
+        let choices = TIME_WINDOW_CHOICES.slice()
+        choices.reverse()
+        let choice = choices.find(c => c.value <= deltaSeconds)
+        if (choice) {
+            value = choice.value
+        }
+
+        this._timeWindowChoiceButtons.choicebuttons('setValue', value)
+    }
+
+    timeWindowToChart() {
+        let deltaMilliseconds = this._timeWindowChoiceButtons.choicebuttons('getValue') * 1000
+        let to = this.getXRange().max
+        let from = to - deltaMilliseconds
+        this.fetchAndShowHistory(from, to)
+        this.setXRange(from, to)
+    }
+
+    showPrevTimeWindow() {
+        let deltaMilliseconds = this._timeWindowChoiceButtons.choicebuttons('getValue') * 1000
+        let to = this.getXRange().max - deltaMilliseconds
+        let from = to - deltaMilliseconds
+        this.fetchAndShowHistory(from, to)
+        this.setXRange(from, to)
+    }
+
+    showNextTimeWindow() {
+        let deltaMilliseconds = this._timeWindowChoiceButtons.choicebuttons('getValue') * 1000
+        let from = this.getXRange().min + deltaMilliseconds
+        let to = from + deltaMilliseconds
+        this.fetchAndShowHistory(from, to)
+        this.setXRange(from, to)
+    }
+
+    makeOptionsBarContent() {
+        return new PortHistoryChartPageOptionsForm({
+            chartPage: this,
+            showSmooth: !this._isBoolean,
+            showFillArea: true,
+            prefsPrefix: `ports.${this._port['id']}.history_chart`,
+            defaults: {
+                smooth: !this._isBoolean,
+                fillArea: false
+            }
+        })
+    }
+
+}
+
+
+export default PortHistoryChartPage

--- a/qtoggleserver/frontend/js/qtoggle-stock.js
+++ b/qtoggleserver/frontend/js/qtoggle-stock.js
@@ -20,15 +20,16 @@ Stocks.register('qtoggle', function () {
             'panel-group': 5,
             'panel': 6,
             'provisioning': 7,
-            'widget-on-off-button': 8,
-            'widget-slider': 9,
-            'widget-on-off-indicator': 10,
-            'widget-push-button': 11,
-            'widget-text': 12,
-            'widget-video': 13,
-            'widget-plus-minus': 14,
-            'widget-radio': 15,
-            'widget-progress-bar': 16
+            'chart': 8,
+            'widget-on-off-button': 18,
+            'widget-slider': 19,
+            'widget-on-off-indicator': 20,
+            'widget-push-button': 21,
+            'widget-text': 22,
+            'widget-video': 23,
+            'widget-plus-minus': 24,
+            'widget-radio': 25,
+            'widget-progress-bar': 26
         }
     })
 })

--- a/qtoggleserver/frontend/js/settings/client-settings.js
+++ b/qtoggleserver/frontend/js/settings/client-settings.js
@@ -4,7 +4,6 @@
 
 import Logger from '$qui/lib/logger.module.js'
 
-import Config      from '$qui/config.js'
 import * as Theme  from '$qui/theme.js'
 import * as Window from '$qui/window.js'
 

--- a/qtoggleserver/frontend/js/widgets/bar-chart.js
+++ b/qtoggleserver/frontend/js/widgets/bar-chart.js
@@ -1,0 +1,80 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import * as Colors      from '$qui/utils/colors.js'
+import * as ObjectUtils from '$qui/utils/object.js'
+
+import './base-chart.js'
+
+
+$.widget('qtoggle.barchart', $.qtoggle.basechart, {
+    /* Expected format for value is one of:
+     *  * [v0, v1, ...]
+     *  * [[v0a, v1a, ...], [v0b, v1b, ...], ...]
+     */
+
+    options: {
+        yMin: null,
+        yMax: null,
+        stacked: false
+    },
+
+    type: 'bar',
+
+    _makeScalesOptions: function (environment) {
+        /* min/max values must be supplied as undefined if not specified */
+        let yMin = this.options.yMin == null ? undefined : this.options.yMin
+        let yMax = this.options.yMax == null ? undefined : this.options.yMax
+
+        return ObjectUtils.combine(this._super(environment), {
+            x: {
+                type: 'category',
+                gridLines: this._makeGridLinesOptions(environment),
+                ticks: this._makeTicksOptions(environment, 'x'),
+                stacked: this.options.stacked
+            },
+            y: {
+                type: 'linear',
+                min: yMin,
+                max: yMax,
+                gridLines: this._makeGridLinesOptions(environment),
+                ticks: this._makeTicksOptions(environment, 'y'),
+                stacked: this.options.stacked
+            }
+        })
+    },
+
+    _makeTooltipOptions: function (environment) {
+        return ObjectUtils.combine(this._super(environment), {
+            mode: 'nearest'
+        })
+    },
+
+    _adaptDatasets: function (data, environment, colors) {
+        if (!Array.isArray(data) || data.length === 0) {
+            return []
+        }
+
+        /* Normalize [v0, v1, ...] -> [[v0, v1, ...]] */
+        if (!Array.isArray(data[0])) {
+            data = [data]
+        }
+
+        if (data[0].length === 0) {
+            return []
+        }
+
+        /* Map input data to axes & adapt datasets */
+        return data.map(function (dataset, i) {
+            let color = colors[i % colors.length]
+            return {
+                hoverBackgroundColor: Colors.alpha(color, 0.75),
+                backgroundColor: color,
+                borderColor: color,
+                borderWidth: 0,
+                data: dataset.map((v, j) => ({x: j, y: v}))
+            }
+        })
+    }
+
+})

--- a/qtoggleserver/frontend/js/widgets/base-chart.js
+++ b/qtoggleserver/frontend/js/widgets/base-chart.js
@@ -1,0 +1,488 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import * as Theme       from '$qui/theme.js'
+import * as Colors      from '$qui/utils/colors.js'
+import * as CSS         from '$qui/utils/css.js'
+import * as DateUtils   from '$qui/utils/date.js'
+import * as ObjectUtils from '$qui/utils/object.js'
+import * as BaseWidget  from '$qui/widgets/base-widget.js' /* Needed */
+import * as Window      from '$qui/window.js'
+
+import * as ChartJS from '$app/lib/chartjs.module.js'
+import Hammer       from '$app/lib/hammer.module.js'
+
+import '$app/lib/chartjs-plugin-zoom.js'
+import '$node/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.js'
+
+
+const DEFAULT_COLORS = [
+    '@green-color',
+    '@orange-color',
+    '@blue-color',
+    '@magenta-color',
+    '@red-color',
+    '@foreground-color'
+]
+
+const FORMATS = {
+    datetime: '%b %-d, %Y, %H:%M:%S',
+    millisecond: '%H:%M:%S.%f',
+    second: '%H:%M:%S',
+    minute: '%H:%M',
+    hour: '%H:%M',
+    day: '%b %-d',
+    week: '%b %-d',
+    month: '%b %Y',
+    quarter: '%b %Y',
+    year: '%Y'
+}
+
+/* Use custom date/time formatter */
+ChartJS._adapters._date.override({
+
+    formats() {
+        return FORMATS
+    },
+
+    format(time, fmt) {
+        return DateUtils.formatPercent(new Date(time), fmt)
+    }
+
+})
+
+
+$.widget('qtoggle.basechart', $.qui.basewidget, {
+
+    options: {
+        title: null,
+        legend: null,
+        showTooltips: false,
+        colors: DEFAULT_COLORS,
+        labels: null,
+        categories: null,
+        unitOfMeasurement: null,
+        panZoomMode: null,
+        panZoomXMin: null,
+        panZoomXMax: null,
+        panZoomYMin: null,
+        panZoomYMax: null,
+        scalingFactor: 1,
+        aspectRatio: 2,
+        onPanZoomStart: function (xMin, xMax, yMin, yMax) {},
+        onPanZoomEnd: function (xMin, xMax, yMin, yMax) {}
+    },
+
+    type: 'override-me',
+
+    _create: function () {
+        this._initChartJS()
+
+        this.element.addClass(`qtoggle-chart-container qtoggle-${this.type}-chart-container`)
+
+        if (this.options.disabled) {
+            this.element.addClass('disabled')
+        }
+        else {
+            this.element.attr('tabIndex', 0) /* Make element focusable */
+        }
+
+        this._scalingFactor = Window.getScalingFactor() * this.options.scalingFactor
+
+        /* We need to compensate the global scaling factor, if any; the chart looks blurry otherwise. */
+        if (Window.getScalingFactor() !== 1) {
+            let compZoom = 100 / Window.getScalingFactor()
+            this.element.css('zoom', `${compZoom}%`)
+        }
+
+        this._canvas = $('<canvas></canvas>', {class: 'qtoggle-chart'})
+        this._canvasContext = this._canvas[0].getContext('2d')
+        this.element.append(this._canvas)
+
+        /* Temporarily add the chart element to DOM - it seems Chart.js needs this */
+        Window.$body.append(this.element)
+
+        this._data = {}
+        this._chart = new ChartJS.Chart(this._canvasContext, {
+            type: this.type,
+            data: {},
+            options: this._prepareOptions(this._getEnvironment())
+        })
+
+        this.element.remove()
+
+        /* Register a double-tap event to reset zoom */
+        if (this._chart._mc) {
+            this._chart._mc.add(new Hammer.Tap({
+                event: 'doubletap',
+                taps: 2
+            }))
+
+            this._chart._mc.on('doubletap', function (e) {
+                this._chart.resetZoom()
+            }.bind(this))
+        }
+
+        this._panning = false
+        this._zooming = false
+    },
+
+    _initChartJS: function () {
+        if (!ChartJS.Chart._qToggleInitialized) {
+            ChartJS.Chart.register(
+                ChartJS.LineController,
+                ChartJS.BarController,
+                ChartJS.DoughnutController,
+                ChartJS.LineElement,
+                ChartJS.BarElement,
+                ChartJS.PointElement,
+                ChartJS.ArcElement,
+                ChartJS.LinearScale,
+                ChartJS.CategoryScale,
+                ChartJS.TimeScale,
+                ChartJS.Legend,
+                ChartJS.Title,
+                ChartJS.Tooltip,
+                ChartJS.Filler
+            )
+
+            ChartJS.Chart._qToggleInitialized = true
+        }
+    },
+
+    getValue: function () {
+        return this._data
+    },
+
+    setValue: function (value) {
+        this._data = value
+        this._chart.data = this._prepareData(this._data)
+        this._chart.update()
+    },
+
+    getXRange: function () {
+        return {
+            min: this._chart.scales['x'].min,
+            max: this._chart.scales['x'].max
+        }
+    },
+
+    setXRange: function (xMin, xMax) {
+        this._chart.scales['x'].options.min = xMin
+        this._chart.scales['x'].options.max = xMax
+    },
+
+    getYRange: function () {
+        return {
+            min: this._chart.scales['y'].min,
+            max: this._chart.scales['y'].max
+        }
+    },
+
+    setYRange: function (yMin, yMax) {
+        this._chart.scales['y'].options.min = yMin
+        this._chart.scales['y'].options.max = yMax
+        this._chart.update()
+    },
+
+    _getEnvironment: function () {
+        let em2px = CSS.em2px(this._scalingFactor)
+
+        return {
+            foregroundColor: Theme.getColor('@foreground-color'),
+            backgroundColor: Theme.getColor('@background-color'),
+            backgroundRootColor: Theme.getColor('@background-root-color'),
+            foregroundActiveColor: Theme.getColor('@foreground-active-color'),
+            borderColor: Theme.getColor('@border-color'),
+            fontFamily: Theme.getVar('base-font-family'),
+            em2px: em2px,
+            px1: em2px * 0.0625,
+            px2: em2px * 0.125,
+            px3: em2px * 0.1875,
+            px4: em2px * 0.25
+        }
+    },
+
+    _getColors: function () {
+        return this.options.colors.map(Theme.getColor)
+    },
+
+    _prepareOptions: function (environment) {
+        return {
+            responsive: true,
+            maintainAspectRatio: true,
+            aspectRatio: this.options.aspectRatio,
+            spanGaps: true,
+            animation: {
+                duration: 0
+            },
+            hover: this._makeHoverOptions(environment),
+            scales: this._makeScalesOptions(environment),
+            plugins: this._makePluginsOptions(environment),
+            elements: this._makeElementsOptions(environment)
+        }
+    },
+
+    _prepareData: function (data) {
+        let labels = this.options.labels
+        if (!labels) {
+            labels = this.options.colors.map(() => '')
+        }
+
+        let datasets = this._adaptDatasets(data, this._getEnvironment(), this._getColors())
+        datasets.forEach(function (ds, i) {
+            ObjectUtils.setDefault(ds, 'label', labels[i])
+        })
+
+        return {
+            labels: this.options.categories,
+            datasets: datasets
+        }
+    },
+
+    _adaptDatasets: function (data, environment, colors) {
+        return data
+    },
+
+    _makeHoverOptions: function (environment) {
+        return {
+            mode: 'nearest',
+            intersect: true
+        }
+    },
+
+    _makeTitleOptions: function (environment) {
+        return {
+            display: this.options.title != null,
+            font: this._makeFontOptions(environment),
+            text: this.options.title
+        }
+    },
+
+    _makeLegendOptions: function (environment) {
+        return {
+            display: this.options.legend != null,
+            position: this.options.legend,
+            labels: {
+                font: this._makeFontOptions(environment),
+                padding: environment.em2px * 0.5,
+                usePointStyle: true,
+                boxWidth: environment.px4,
+                generateLabels: function (chart) {
+                    /* Hack to force fill color to be the same as stroke (border) color */
+                    let labels = ChartJS.Chart.defaults.plugins.legend.labels.generateLabels(chart)
+                    labels.forEach(function (label) {
+                        label.fillStyle = label.strokeStyle
+                    })
+
+                    return labels
+                }
+            }
+        }
+    },
+
+    _makeScalesOptions: function (environment) {
+        return {}
+    },
+
+    _makeGridLinesOptions: function (environment) {
+        return {
+            color: environment.borderColor,
+            lineWidth: environment.px1
+        }
+    },
+
+    _makeTicksOptions: function (environment, scaleName) {
+        return {
+            color: environment.foregroundActiveColor,
+            font: ObjectUtils.combine(this._makeFontOptions(environment), {
+                size: environment.em2px * 0.75
+            }),
+            callback: scaleName === 'y' ? function (value, index, values) { /* Show units on vertical axis */
+                return `${value}${this.options.unitOfMeasurement || ''}`
+            }.bind(this) : null
+        }
+    },
+
+    _makeTooltipOptions: function (environment) {
+        let colors = this._getColors()
+
+        return {
+            enabled: this.options.showTooltips,
+            mode: 'index',
+            intersect: true,
+            animation: {
+                duration: 50
+            },
+            backgroundColor: Colors.alpha(environment.backgroundRootColor, 0.9),
+            borderColor: environment.foregroundColor,
+            borderWidth: environment.px1 / 2, /* No idea why this actually results in a 1px border */
+            usePointStyle: true,
+            boxWidth: environment.em2px * 0.4,
+            boxHeight: environment.em2px * 0.4,
+            titleFont: ObjectUtils.combine(this._makeFontOptions(environment), {
+                size: environment.em2px * 0.8
+            }),
+            bodyFont: ObjectUtils.combine(this._makeFontOptions(environment), {
+                size: environment.em2px * 0.8
+            }),
+            titleColor: environment.foregroundColor,
+            bodyColor: environment.foregroundColor,
+            callbacks: {
+                labelColor: function (context) {
+                    /* Hack to force fill color to be the same as stroke (border) color */
+                    return {
+                        borderColor: environment.foregroundColor,
+                        backgroundColor: colors[context.datasetIndex % colors.length]
+                    }
+                },
+                label: function (context) {
+                    return ` ${context.dataPoint.y}${this.options.unitOfMeasurement || ''}`
+                }.bind(this)
+            }
+        }
+    },
+
+    _makePluginsOptions: function (environment) {
+        let plugins = {
+            title: this._makeTitleOptions(environment),
+            legend: this._makeLegendOptions(environment),
+            tooltip: this._makeTooltipOptions(environment)
+        }
+
+        if (this.options.panZoomMode) {
+            plugins.zoom = this._makeZoomPluginOptions(environment)
+        }
+
+        return plugins
+    },
+
+    _makeElementsOptions: function (environment) {
+        return {
+            point: {
+                hitRadius: environment.em2px / 2
+            }
+        }
+    },
+
+    _makeZoomPluginOptions: function (environment) {
+        return {
+            pan: {
+                enabled: true,
+                mode: this.options.panZoomMode,
+                speed: 0.1,
+                rangeMin: {
+                    x: this.options.panZoomXMin != null ? this.options.panZoomXMin : undefined,
+                    y: this.options.panZoomYMin != null ? this.options.panZoomYMin : undefined
+                },
+                rangeMax: {
+                    x: this.options.panZoomXMax != null ? this.options.panZoomXMax : undefined,
+                    y: this.options.panZoomYMax != null ? this.options.panZoomYMax : undefined
+                },
+                onPan: function () {
+                    if (!this._panning) {
+                        this._panning = true
+                        if (!this._zooming) {
+                            this._handlePanZoomStart()
+                        }
+                    }
+                }.bind(this),
+                onPanComplete: function () {
+                    if (!this._zooming && this._panning) {
+                        this._handlePanZoomEnd()
+                    }
+                    this._panning = false
+                }.bind(this)
+            },
+            zoom: {
+                enabled: true,
+                mode: this.options.panZoomMode,
+                speed: 0.2,
+                rangeMax: {
+                    x: this.options.panZoomXMax != null ? this.options.panZoomXMax : undefined,
+                    y: this.options.panZoomYMax != null ? this.options.panZoomYMax : undefined
+                },
+                onZoom: function () {
+                    if (!this._zooming) {
+                        this._zooming = true
+                        if (!this._panning) {
+                            this._handlePanZoomStart()
+                        }
+                    }
+                }.bind(this),
+                onZoomComplete: function () {
+                    if (!this._panning && this._zooming) {
+                        this._handlePanZoomEnd()
+                    }
+                    this._zooming = false
+                }.bind(this)
+            }
+        }
+    },
+
+    _makeFontOptions: function (environment) {
+        return {
+            family: environment.fontFamily,
+            style: 'normal',
+            size: environment.em2px
+        }
+    },
+
+    _handlePanZoomStart: function () {
+        let xMin = this._chart.scales['x'].min
+        let xMax = this._chart.scales['x'].max
+        let yMin = this._chart.scales['y'].min
+        let yMax = this._chart.scales['y'].max
+
+        this.options.onPanZoomStart(xMin, xMax, yMin, yMax)
+    },
+
+    _handlePanZoomEnd: function () {
+        let xMin = this._chart.scales['x'].min
+        let xMax = this._chart.scales['x'].max
+        let yMin = this._chart.scales['y'].min
+        let yMax = this._chart.scales['y'].max
+
+        this.options.onPanZoomEnd(xMin, xMax, yMin, yMax)
+    },
+
+    _setOption: function (key, value) {
+        this._super(key, value)
+
+        switch (key) {
+            case 'disabled':
+                this.element.toggleClass('disabled', value)
+                if (value) {
+                    this.element.removeAttr('tabIndex')
+                }
+                else {
+                    this.element.attr('tabIndex', 0)
+                }
+                break
+        }
+
+        /* Preserve scale ranges */
+        let scaleRanges = ObjectUtils.mapValue(this._chart.scales, scale => ({
+            min: scale.options.min,
+            max: scale.options.max
+        }))
+        let options = this._prepareOptions(this._getEnvironment())
+
+        this._chart.data = this._prepareData(this._data)
+        ObjectUtils.forEach(scaleRanges, function (scaleName, {min, max}) {
+            let scale = options.scales[scaleName]
+            if (!scale) {
+                return
+            }
+
+            if (min != null && max != null) {
+                scale.min = min
+                scale.max = max
+            }
+        })
+
+        this._chart.options = options
+        this._chart.update()
+    }
+
+})

--- a/qtoggleserver/frontend/js/widgets/line-chart.js
+++ b/qtoggleserver/frontend/js/widgets/line-chart.js
@@ -1,0 +1,228 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import * as ArrayUtils  from '$qui/utils/array.js'
+import * as Colors      from '$qui/utils/colors.js'
+import * as ObjectUtils from '$qui/utils/object.js'
+
+import './base-chart.js'
+
+
+const SHOW_POINTS_AUTO_VISIBLE_MAX = 200
+
+
+$.widget('qtoggle.linechart', $.qtoggle.basechart, {
+    /* Expected format for value is one of:
+     *  * [y0, y1, ...]
+     *  * [[x0, y0a, y0b, ...], [x1, y1a, y1b, ...], ...]
+     *  * [[[x0a, y0a], [x1a, y1a], ...], [[x0b, y0b], [x1b, y1b], ...], ...] */
+
+    options: {
+        xMin: null,
+        xMax: null,
+        yMin: null,
+        yMax: null,
+        showPoints: null, /* null = auto */
+        showMajorTicks: false,
+        allowTickRotation: false,
+        xTicksStepSize: null,
+        yTicksStepSize: null,
+        xTicksLabelCallback: null,
+        yTicksLabelCallback: null,
+        smooth: true,
+        fillArea: true,
+        stepped: false
+    },
+
+    type: 'line',
+
+    _create: function () {
+        this._super()
+
+        this._pointRadius = null
+    },
+
+    _makeScalesOptions: function (environment) {
+        /* min/max values must be supplied as undefined if not specified */
+        let xMin = this.options.xMin == null ? undefined : this.options.xMin
+        let xMax = this.options.xMax == null ? undefined : this.options.xMax
+        let yMin = this.options.yMin == null ? undefined : this.options.yMin
+        let yMax = this.options.yMax == null ? undefined : this.options.yMax
+
+        return ObjectUtils.combine(this._super(environment), {
+            x: {
+                type: 'linear',
+                min: xMin,
+                max: xMax,
+                gridLines: this._makeGridLinesOptions(environment),
+                ticks: this._makeTicksOptions(environment, 'x')
+            },
+            y: {
+                type: 'linear',
+                min: yMin,
+                max: yMax,
+                gridLines: this._makeGridLinesOptions(environment),
+                ticks: this._makeTicksOptions(environment, 'y')
+            }
+        })
+    },
+
+    _makeTicksOptions: function (environment, scaleName) {
+        let options = this._super(environment, scaleName)
+
+        // eslint-disable-next-line no-undef-init
+        let stepSize = undefined
+        // eslint-disable-next-line no-undef-init
+        let labelCallback = undefined
+        if (scaleName === 'x') {
+            if (this.options.xTicksStepSize != null) {
+                stepSize = this.options.xTicksStepSize
+            }
+            if (this.options.xTicksLabelCallback) {
+                labelCallback = this.options.xTicksLabelCallback
+            }
+        }
+        else if (scaleName === 'y') {
+            if (this.options.yTicksStepSize != null) {
+                stepSize = this.options.yTicksStepSize
+            }
+            if (this.options.yTicksLabelCallback) {
+                labelCallback = this.options.yTicksLabelCallback
+            }
+            else {
+                labelCallback = function (value, index, values) { /* Show units on vertical axis, by default */
+                    return `${value}${this.options.unitOfMeasurement || ''}`
+                }.bind(this)
+            }
+        }
+
+        return ObjectUtils.combine(options, {
+            autoSkip: false,
+            autoSkipPadding: environment.em2px / 2,
+            maxRotation: this.options.allowTickRotation ? null : 0,
+            stepSize: stepSize,
+            major: {
+                enabled: this.options.showMajorTicks
+            },
+            font: function (context) {
+                return ObjectUtils.combine(options.font, {
+                    style: context.tick && context.tick.major ? 'bold' : 'normal'
+                })
+            },
+            callback: labelCallback
+        })
+    },
+
+    _makeElementsOptions: function (environment) {
+        return ObjectUtils.combine(this._super(environment), {
+            line: {
+                tension: this.options.smooth ? 0.4 : 0,
+                borderDash: []
+            }
+        })
+    },
+
+    _adaptDatasets: function (data, environment, colors) {
+        if (!Array.isArray(data) || data.length === 0) {
+            return []
+        }
+
+        /* Normalize [y0, y1, ...] -> [[0, y0], [1, y1], ...] */
+        if (!Array.isArray(data[0])) {
+            data = data.map((v, i) => [i, v])
+        }
+
+        if (data[0].length === 0) {
+            return []
+        }
+
+        /* Normalize [[x0, y0a, y0b, ...], [x1, y1a, y1b, ...], ...] ->
+         *           [[[x0, y0a], [x1, y1a], ...], [[x0, y0b], [x1, y1b], ...], ...] */
+        if (!Array.isArray(data[0][0])) {
+            /* The data is assumed to be a list of multidimensional points.
+             * The first point is used to determine the number of datasets; its first dimension is the x axis. */
+
+            let datasetCount = data[0].length - 1
+            data = ArrayUtils.range(0, datasetCount).map(function (i) {
+                return data.map(p => [p[0], p[i + 1]])
+            })
+        }
+
+        /* Map input data to axes & adapt datasets */
+        return data.map(function (dataset, i) {
+            let color = colors[i % colors.length]
+            return {
+                borderColor: color,
+                borderCapStyle: 'round',
+                borderJoinStyle: 'round',
+                hoverBorderColor: color,
+                hoverBackgroundColor: color,
+                backgroundColor: environment.backgroundColor,
+                borderWidth: environment.px2,
+                pointStyle: 'circle',
+                pointBorderWidth: environment.px1,
+                pointHoverBorderWidth: environment.px1,
+                pointRadius: this._getPointRadius.bind(this, environment),
+                pointHoverRadius: this.options.showPoints !== false ? environment.px3 : 0,
+                stepped: this.options.stepped,
+                fill: this.options.fillArea ? {
+                    target: 'origin',
+                    above: Colors.alpha(color, 0.2),
+                    below: Colors.alpha(color, 0.2)
+                } : null,
+                data: dataset.map(pair => ({x: pair[0], y: pair[1]}))
+            }
+        }.bind(this))
+    },
+
+    _handlePanZoomStart() {
+        this._super()
+
+        /* Invalidate point radius */
+        this._pointRadius = null
+    },
+
+    _getPointRadius(environment, context) {
+        if (this.options.showPoints === false) {
+            return 0
+        }
+        if (this.options.showPoints === true) {
+            return environment.px3
+        }
+        if (this._pointRadius != null) {
+            return this._pointRadius
+        }
+
+        let scaleX = context.chart.scales['x']
+        let scaleY = context.chart.scales['y']
+        let data = context.dataset.data
+
+        let visibleXCount = 0
+        let visibleYCount = 0
+        for (let i = 0; i < data.length; i++) {
+            let point = data[i]
+            if (scaleX.min <= point.x && scaleX.max >= point.x) {
+                visibleXCount++
+            }
+            if (scaleY.min <= point.y && scaleY.max >= point.y) {
+                visibleYCount++
+            }
+            if (visibleXCount > SHOW_POINTS_AUTO_VISIBLE_MAX && visibleYCount > SHOW_POINTS_AUTO_VISIBLE_MAX) {
+                return (this._pointRadius = 0)
+            }
+        }
+
+        return (this._pointRadius = environment.px3)
+    },
+
+    _setOption: function (key, value) {
+        switch (key) {
+            case 'showPoints':
+                this._pointRadius = null
+                break
+        }
+
+        this._super(key, value)
+    }
+
+})

--- a/qtoggleserver/frontend/js/widgets/pie-chart.js
+++ b/qtoggleserver/frontend/js/widgets/pie-chart.js
@@ -1,0 +1,52 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import * as Colors      from '$qui/utils/colors.js'
+import * as ObjectUtils from '$qui/utils/object.js'
+
+import './base-chart.js'
+
+
+$.widget('qtoggle.piechart', $.qtoggle.basechart, {
+    /* Expected format for value is one of:
+     *  * [v0, v1, ...]
+     */
+
+    options: {
+    },
+
+    type: 'doughnut',
+
+    _makeTooltipOptions: function (environment) {
+        return ObjectUtils.combine(this._super(environment), {
+            callbacks: {
+                labelColor: function (context) {
+                    /* Hack to force fill color to be the same as stroke (border) color */
+                    return {
+                        borderColor: environment.foregroundColor,
+                        backgroundColor: context.element.options.backgroundColor
+                    }
+                },
+                label: function (context) {
+                    return ` ${context.dataPoint}${this.options.unitOfMeasurement || ''}`
+                }.bind(this)
+            }
+        })
+    },
+
+    _adaptDatasets: function (data, environment, colors) {
+        if (!Array.isArray(data) || data.length === 0) {
+            return []
+        }
+
+        return [{
+            backgroundColor: colors,
+            hoverBackgroundColor: colors.map(c => Colors.alpha(c, 0.75)),
+            borderColor: environment.backgroundColor,
+            hoverBorderColor: environment.backgroundColor,
+            borderWidth: environment.px2,
+            data: data
+        }]
+    }
+
+})

--- a/qtoggleserver/frontend/js/widgets/time-chart.js
+++ b/qtoggleserver/frontend/js/widgets/time-chart.js
@@ -1,0 +1,30 @@
+
+import $ from '$qui/lib/jquery.module.js'
+
+import './line-chart.js'
+
+
+$.widget('qtoggle.timechart', $.qtoggle.linechart, {
+    /* Expected format for value is one of:
+     *  * [[t0, y0a, y0b, ...], [t1, y1a, y1b, ...], ...]
+     *  * [[[t0a, y0a], [t1a, y1a], ...], [[t0b, y0b], [t1b, y1b], ...], ...]
+     *
+     * Time values must be given as Unix timestamps in milliseconds.
+     */
+
+    options: {
+        unit: null
+    },
+
+    _makeScalesOptions: function (environment) {
+        let options = this._super(environment)
+
+        options.x.type = 'time'
+        options.x.time = {
+            unit: this.options.unit ? this.options.unit : undefined
+        }
+
+        return options
+    }
+
+})

--- a/qtoggleserver/frontend/less/common.less
+++ b/qtoggleserver/frontend/less/common.less
@@ -1,0 +1,13 @@
+
+@import (reference) "@{qui_less_path}/theme";
+
+
+div.qtoggle-chart-page-view {
+    background: @background-color;
+    width: 80%;
+
+    div.qtoggle-chart-page-chart-container {
+        margin: 1.5em 0.5em 0.5em 0.5em;
+    }
+
+}

--- a/qtoggleserver/frontend/less/ports/ports.less
+++ b/qtoggleserver/frontend/less/ports/ports.less
@@ -1,0 +1,30 @@
+
+@import (reference) "@{qui_less_path}/theme";
+
+
+div.ports-history-chart-page-navigation {
+    text-align: right;
+    padding: 0.5em;
+
+    body.small-screen & {
+        display: grid;
+        grid-template-columns: 1fr 7fr 1fr;
+    }
+
+    div.ports-history-chart-time-window-choice-buttons {
+        display: inline-block;
+        margin: 0 0.5em;
+        vertical-align: middle;
+
+        div.qui-choice-button {
+            min-width: 3em;
+        }
+
+    }
+
+    div.ports-history-chart-prev-button,
+    div.ports-history-chart-next-button {
+        min-width: 2.5em;
+    }
+
+}

--- a/qtoggleserver/frontend/less/widgets.less
+++ b/qtoggleserver/frontend/less/widgets.less
@@ -1,0 +1,20 @@
+
+@import (reference) "@{qui_less_path}/theme";
+
+div.qtoggle-chart-container {
+
+    position: relative;
+
+    &.disabled {
+        pointer-events: none;
+        filter: saturate(0);
+    }
+
+    canvas.qtoggle-chart {
+        image-rendering: pixelated;
+
+        width: 100%;
+        height: 100%;
+    }
+
+}

--- a/qtoggleserver/frontend/package-lock.json
+++ b/qtoggleserver/frontend/package-lock.json
@@ -117,9 +117,9 @@
             }
         },
         "@qtoggle/qui": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/@qtoggle/qui/-/qui-1.13.5.tgz",
-            "integrity": "sha512-/nCEaiwIuAcudu9UaqVXUqYVVt+shNutzD8jcCElRqlG+3yZre3w4n0i3e07vTngbsqOy1SzQHq2vGZF97m2Vw==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@qtoggle/qui/-/qui-1.14.0.tgz",
+            "integrity": "sha512-m1J/58Cw+Wjz/KoXQGkCh6ve1UybMbN1k80j4v69S1qpu5pSSY00oDXofwohhI9EfUGjvexll8j4kwGDmubuFQ==",
             "requires": {
                 "jquery": "*",
                 "jquery-mousewheel": "*",
@@ -1096,6 +1096,16 @@
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
+        },
+        "chart.js": {
+            "version": "3.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.0.0-beta.7.tgz",
+            "integrity": "sha512-UL0HlWNRBvvzGPoh0WfmsiaLuYdgjLj9PtutfEjL43eJxxDPHWmsqROJT7x81oyF6TVrFs2uR5UEkt0GfhGxxw=="
+        },
+        "chartjs-adapter-date-fns": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-1.0.0.tgz",
+            "integrity": "sha512-G7gk8IzCJmg7kH7Hhp4upJ7mOhN9ipGR2w0pnG+/aYnNno2rada6wzvxeWV6hpYSr/UT/E3AnQAM4z994JarVw=="
         },
         "chokidar": {
             "version": "2.1.8",
@@ -3266,6 +3276,11 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
             "dev": true
+        },
+        "hammerjs": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+            "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
         },
         "har-schema": {
             "version": "2.0.0",

--- a/qtoggleserver/frontend/package.json
+++ b/qtoggleserver/frontend/package.json
@@ -7,6 +7,9 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@qtoggle/qui": "*",
+        "chart.js": "^3.0.0-beta.7",
+        "chartjs-adapter-date-fns": "*",
+        "hammerjs": "*",
         "jquery": "*",
         "jquery-mousewheel": "*",
         "jquery-ui-dist": "*",

--- a/qtoggleserver/frontend/templates/index.html
+++ b/qtoggleserver/frontend/templates/index.html
@@ -5,6 +5,7 @@
     {% if debug %}
         {% for theme in themes %}
             {{ css_devel_file(theme, "common.css") }}
+            {{ css_devel_file(theme, "widgets.css") }}
 
             {{ css_devel_file(theme, "dashboard/dashboard.css") }}
             {{ css_devel_file(theme, "dashboard/widgets/analog-widget.css") }}
@@ -18,6 +19,7 @@
             {{ css_devel_file(theme, "dashboard/widgets/slider.css") }}
             {{ css_devel_file(theme, "dashboard/widgets/text-indicator.css") }}
 
+            {{ css_devel_file(theme, "ports/ports.css") }}
             {{ css_devel_file(theme, "devices/devices.css") }}
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
* frontend: Add chart.js base widget
* frontend: Add line chart widget
* frontend: Add time chart widget
* frontend: Add bar chart widget
* frontend: Add pie chart widget
* frontend: Add ChartPage
* frontend: Update qui to 1.14.0
* frontend/common: Add and use HistoryDownloadManager
* frontend/ports: Add PortHistoryChartPage
* history: Increase max download limit to 10k
* pages: Separate modal and popup properties