### PR TITLE
tests: Addexpression tests

### DIFF
--- a/qtoggleserver/core/expressions/arithmetic.py
+++ b/qtoggleserver/core/expressions/arithmetic.py
@@ -1,5 +1,6 @@
 
 from .functions import function, Function
+from .exceptions import ExpressionArithmeticError
 
 
 @function('ADD')
@@ -42,7 +43,7 @@ class DivFunction(Function):
             return eval_args[0] / eval_args[1]
 
         else:
-            return 0
+            raise ExpressionArithmeticError
 
 
 @function('MOD')
@@ -56,7 +57,7 @@ class ModFunction(Function):
             return eval_args[0] % eval_args[1]
 
         else:
-            return 0
+            raise ExpressionArithmeticError
 
 
 @function('POW')

--- a/qtoggleserver/core/expressions/exceptions.py
+++ b/qtoggleserver/core/expressions/exceptions.py
@@ -151,6 +151,10 @@ class UndefinedPortValue(IncompleteExpression):
         super().__init__(f'Port "{port_id}" value is undefined')
 
 
+class ExpressionArithmeticError(IncompleteExpression):
+    pass
+
+
 class EvalSkipped(ExpressionEvalError):
     def __init__(self) -> None:
         super().__init__('Evaluation skipped')

--- a/qtoggleserver/core/expressions/functions.py
+++ b/qtoggleserver/core/expressions/functions.py
@@ -28,7 +28,6 @@ class Function(Expression, metaclass=abc.ABCMeta):
 
     def __init__(self, args: List[Expression]) -> None:
         self.args: List[Expression] = args
-        self._deps: Optional[Set[str]] = None
 
     def __str__(self) -> str:
         s = getattr(self, '_str', None)
@@ -39,13 +38,11 @@ class Function(Expression, metaclass=abc.ABCMeta):
         return s
 
     def get_deps(self) -> Set[str]:
-        if self._deps is None:
-            self._deps = set()
+        deps = set()
+        for arg in self.args:
+            deps |= arg.get_deps()
 
-            for arg in self.args:
-                self._deps |= arg.get_deps()
-
-        return self._deps
+        return deps
 
     def eval_args(self) -> List[float]:
         return [a.eval() for a in self.args]

--- a/qtoggleserver/core/expressions/timeprocessing.py
+++ b/qtoggleserver/core/expressions/timeprocessing.py
@@ -249,13 +249,15 @@ class FMAvgFunction(Function):
                 raise EvalSkipped()
 
         # Make place for the new element
-        while len(self._queue) > width:
+        while len(self._queue) >= width:
             self._queue.pop(0)
 
         self._queue.append(value)
         self._last_time = now
 
-        return sum(self._queue) / len(self._queue)
+        queue = self._queue[-width:]
+
+        return sum(queue) / len(queue)
 
 
 @function('FMEDIAN')
@@ -284,12 +286,13 @@ class FMedianFunction(Function):
                 raise EvalSkipped()
 
         # Make place for the new element
-        while len(self._queue) > width:
+        while len(self._queue) >= width:
             self._queue.pop(0)
 
         self._queue.append(value)
         self._last_time = now
 
-        sorted_queue = list(sorted(self._queue))
+        queue = self._queue[-width:]
+        queue.sort()
 
-        return sorted_queue[len(sorted_queue) // 2]
+        return queue[len(queue) // 2]

--- a/qtoggleserver/core/expressions/various.py
+++ b/qtoggleserver/core/expressions/various.py
@@ -3,7 +3,6 @@ import time
 
 from typing import Optional, Set
 
-from .exceptions import EvalSkipped
 from .functions import function, Function
 
 
@@ -86,9 +85,8 @@ class SequenceFunction(Function):
     def eval(self) -> float:
         now = time.time() * 1000
 
-        if self._last_time > 0:
+        if self._last_time == 0:
             self._last_time = now
-            raise EvalSkipped()
 
         args = self.eval_args()
         num_values = len(args) // 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ flake8
 flake8-annotations
 pytest
 pytest-tornasync
+freezegun
 mongomock
 fakeredis
 testing.postgresql

--- a/tests/qtoggleserver/conftest.py
+++ b/tests/qtoggleserver/conftest.py
@@ -1,0 +1,47 @@
+
+import datetime
+import os
+import time
+
+import pytest
+import pytz
+
+from freezegun import freeze_time
+
+
+tz_info = pytz.timezone('Europe/Bucharest')
+
+
+@pytest.fixture(scope='session')
+def dummy_utc_datetime():
+    return datetime.datetime(2019, 3, 14, 10, 34, 56, microsecond=654321)
+
+
+@pytest.fixture(scope='session')
+def dummy_local_datetime(dummy_utc_datetime):
+    dt = dummy_utc_datetime.replace(tzinfo=pytz.utc)
+    dt = dt.astimezone(tz_info)
+    dt = dt.replace(tzinfo=None)
+
+    os.environ['TZ'] = tz_info.zone
+    time.tzset()
+
+    return dt
+
+
+@pytest.fixture(scope='session')
+def local_tz_info():
+    return tz_info
+
+
+@pytest.fixture
+def freezer(dummy_local_datetime):
+    freezer = freeze_time()
+    frozen_time = freezer.start()
+    yield frozen_time
+    freezer.stop()
+
+
+@pytest.fixture(scope='session')
+def dummy_timestamp():
+    return 1552559696.654321

--- a/tests/qtoggleserver/core/expressions/conftest.py
+++ b/tests/qtoggleserver/core/expressions/conftest.py
@@ -1,0 +1,99 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import literalvalues
+
+
+@pytest.fixture(scope='session')
+def literal_false():
+    return literalvalues.LiteralValue(False, 'false')
+
+
+@pytest.fixture(scope='session')
+def literal_true():
+    return literalvalues.LiteralValue(True, 'true')
+
+
+@pytest.fixture(scope='session')
+def literal_zero():
+    return literalvalues.LiteralValue(0, '0')
+
+
+@pytest.fixture(scope='session')
+def literal_zero_point_five():
+    return literalvalues.LiteralValue(0.5, '0.5')
+
+
+@pytest.fixture(scope='session')
+def literal_one():
+    return literalvalues.LiteralValue(1, '1')
+
+
+@pytest.fixture(scope='session')
+def literal_two():
+    return literalvalues.LiteralValue(2, '2')
+
+
+@pytest.fixture(scope='session')
+def literal_three():
+    return literalvalues.LiteralValue(3, '3')
+
+
+@pytest.fixture(scope='session')
+def literal_pi():
+    return literalvalues.LiteralValue(3.14159, '3.14159')
+
+
+@pytest.fixture(scope='session')
+def literal_ten():
+    return literalvalues.LiteralValue(10, '10')
+
+
+@pytest.fixture(scope='session')
+def literal_ten_point_fifty_one():
+    return literalvalues.LiteralValue(10.51, '10.51')
+
+
+@pytest.fixture(scope='session')
+def literal_sixteen():
+    return literalvalues.LiteralValue(16, '16')
+
+
+@pytest.fixture(scope='session')
+def literal_one_hundred():
+    return literalvalues.LiteralValue(100, '100')
+
+
+@pytest.fixture(scope='session')
+def literal_two_hundreds():
+    return literalvalues.LiteralValue(200, '200')
+
+
+@pytest.fixture(scope='session')
+def literal_one_thousand():
+    return literalvalues.LiteralValue(1000, '1000')
+
+
+@pytest.fixture(scope='session')
+def literal_minus_one():
+    return literalvalues.LiteralValue(-1, '-1')
+
+
+@pytest.fixture(scope='session')
+def literal_minus_two():
+    return literalvalues.LiteralValue(-2, '-2')
+
+
+@pytest.fixture(scope='session')
+def literal_minus_pi():
+    return literalvalues.LiteralValue(-3.14159, '-3.14159')
+
+
+@pytest.fixture(scope='session')
+def literal_minus_ten_point_fifty_one():
+    return literalvalues.LiteralValue(-10.51, '-10.51')
+
+
+@pytest.fixture(scope='session')
+def literal_dummy_timestamp(dummy_timestamp):
+    return literalvalues.LiteralValue(dummy_timestamp, str(dummy_timestamp))

--- a/tests/qtoggleserver/core/expressions/mock.py
+++ b/tests/qtoggleserver/core/expressions/mock.py
@@ -1,0 +1,19 @@
+
+from typing import Optional
+
+from qtoggleserver.core.expressions import Expression
+
+
+class MockExpression(Expression):
+    def __init__(self, value: Optional[float] = None) -> None:
+        self.value: Optional[float] = value
+
+    def set_value(self, value: Optional[float]) -> None:
+        self.value = value
+
+    def eval(self) -> float:
+        return self.value
+
+    @staticmethod
+    def parse(self_port_id: Optional[str], sexpression: str, pos: int) -> Expression:
+        pass

--- a/tests/qtoggleserver/core/expressions/test_aggregation.py
+++ b/tests/qtoggleserver/core/expressions/test_aggregation.py
@@ -1,0 +1,65 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import aggregation, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_min_simple(literal_one, literal_two):
+    result = aggregation.MinFunction([literal_two, literal_one]).eval()
+    assert result == 1
+
+
+def test_min_multiple(literal_one, literal_ten, literal_minus_two):
+    result = aggregation.MinFunction([literal_ten, literal_one, literal_minus_two]).eval()
+    assert result == -2
+
+
+def test_min_parse():
+    e = Function.parse(None, 'MIN(1, 2, 3)', 0)
+    assert isinstance(e, aggregation.MinFunction)
+
+
+def test_min_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MIN(1)', 0)
+
+
+def test_max_simple(literal_one, literal_two):
+    result = aggregation.MaxFunction([literal_two, literal_one]).eval()
+    assert result == 2
+
+
+def test_max_multiple(literal_one, literal_ten, literal_minus_two):
+    result = aggregation.MaxFunction([literal_ten, literal_one, literal_minus_two]).eval()
+    assert result == 10
+
+
+def test_max_parse():
+    e = Function.parse(None, 'MAX(1, 2, 3)', 0)
+    assert isinstance(e, aggregation.MaxFunction)
+
+
+def test_max_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MAX(1)', 0)
+
+
+def test_avg_simple(literal_one, literal_two):
+    result = aggregation.AvgFunction([literal_two, literal_one]).eval()
+    assert result == 1.5
+
+
+def test_avg_multiple(literal_one, literal_ten, literal_minus_two):
+    result = aggregation.AvgFunction([literal_ten, literal_one, literal_minus_two]).eval()
+    assert result == 3
+
+
+def test_avg_parse():
+    e = Function.parse(None, 'AVG(1, 2, 3)', 0)
+    assert isinstance(e, aggregation.AvgFunction)
+
+
+def test_avg_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'AVG(1)', 0)

--- a/tests/qtoggleserver/core/expressions/test_arithmetic.py
+++ b/tests/qtoggleserver/core/expressions/test_arithmetic.py
@@ -1,0 +1,171 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import arithmetic, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments, ExpressionArithmeticError
+
+
+def test_add_simple(literal_one, literal_two):
+    result = arithmetic.AddFunction([literal_one, literal_two]).eval()
+    assert result == 3
+
+
+def test_add_multiple(literal_one, literal_two, literal_minus_one, literal_ten):
+    result = arithmetic.AddFunction([literal_one, literal_two, literal_minus_one, literal_ten]).eval()
+    assert result == 12
+
+
+def test_add_boolean(literal_one, literal_true):
+    result = arithmetic.AddFunction([literal_one, literal_true]).eval()
+    assert result == 2
+
+
+def test_add_parse():
+    e = Function.parse(None, 'ADD(1, 2)', 0)
+    assert isinstance(e, arithmetic.AddFunction)
+
+
+def test_add_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ADD(1)', 0)
+
+
+def test_sub_simple(literal_one, literal_two):
+    result = arithmetic.SubFunction([literal_one, literal_two]).eval()
+    assert result == -1
+
+
+def test_sub_boolean(literal_two, literal_true):
+    result = arithmetic.SubFunction([literal_two, literal_true]).eval()
+    assert result == 1
+
+
+def test_sub_parse():
+    e = Function.parse(None, 'SUB(1, 2)', 0)
+    assert isinstance(e, arithmetic.SubFunction)
+
+
+def test_sub_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SUB(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SUB(1, 2, 3)', 0)
+
+
+def test_mul_simple(literal_two, literal_ten):
+    result = arithmetic.MulFunction([literal_two, literal_ten]).eval()
+    assert result == 20
+
+
+def test_mul_multiple(literal_two, literal_ten, literal_minus_one):
+    result = arithmetic.MulFunction([literal_two, literal_ten, literal_minus_one]).eval()
+    assert result == -20
+
+
+def test_mul_boolean(literal_two, literal_true):
+    result = arithmetic.MulFunction([literal_two, literal_true]).eval()
+    assert result == 2
+
+
+def test_mul_parse():
+    e = Function.parse(None, 'MUL(1, 2)', 0)
+    assert isinstance(e, arithmetic.MulFunction)
+
+
+def test_mul_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MUL(1)', 0)
+
+
+def test_div_integer(literal_ten, literal_two):
+    result = arithmetic.DivFunction([literal_ten, literal_two]).eval()
+    assert result == 5
+
+
+def test_div_float(literal_two, literal_ten):
+    result = arithmetic.DivFunction([literal_two, literal_ten]).eval()
+    assert result == 0.2
+
+
+def test_div_boolean(literal_ten, literal_true, literal_false):
+    result = arithmetic.DivFunction([literal_ten, literal_true]).eval()
+    assert result == 10
+
+    with pytest.raises(ExpressionArithmeticError):
+        arithmetic.DivFunction([literal_ten, literal_false]).eval()
+
+
+def test_div_parse():
+    e = Function.parse(None, 'DIV(1, 2)', 0)
+    assert isinstance(e, arithmetic.DivFunction)
+
+
+def test_div_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DIV(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DIV(1, 2, 3)', 0)
+
+
+def test_mod_integer(literal_ten, literal_two):
+    result = arithmetic.ModFunction([literal_ten, literal_two]).eval()
+    assert result == 0
+
+
+def test_mod_float(literal_three, literal_two):
+    result = arithmetic.ModFunction([literal_three, literal_two]).eval()
+    assert result == 1
+
+
+def test_mod_boolean(literal_ten, literal_true, literal_false):
+    result = arithmetic.ModFunction([literal_ten, literal_true]).eval()
+    assert result == 0
+
+    with pytest.raises(ExpressionArithmeticError):
+        arithmetic.ModFunction([literal_ten, literal_false]).eval()
+
+
+def test_mod_parse():
+    e = Function.parse(None, 'MOD(1, 2)', 0)
+    assert isinstance(e, arithmetic.ModFunction)
+
+
+def test_mod_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MOD(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MOD(1, 2, 3)', 0)
+
+
+def test_pow_integer(literal_ten, literal_two):
+    result = arithmetic.PowFunction([literal_ten, literal_two]).eval()
+    assert result == 100
+
+
+def test_pow_sqrt(literal_sixteen, literal_zero_point_five):
+    result = arithmetic.PowFunction([literal_sixteen, literal_zero_point_five]).eval()
+    assert result == 4
+
+
+def test_pow_boolean(literal_ten, literal_true, literal_false):
+    result = arithmetic.PowFunction([literal_ten, literal_true]).eval()
+    assert result == 10
+
+    result = arithmetic.PowFunction([literal_ten, literal_false]).eval()
+    assert result == 1
+
+
+def test_pow_parse():
+    e = Function.parse(None, 'POW(1, 2)', 0)
+    assert isinstance(e, arithmetic.PowFunction)
+
+
+def test_pow_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'POW(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'POW(1, 2, 3)', 0)

--- a/tests/qtoggleserver/core/expressions/test_bitwise.py
+++ b/tests/qtoggleserver/core/expressions/test_bitwise.py
@@ -1,0 +1,113 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import bitwise, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_bitand_simple(literal_three, literal_ten):
+    result = bitwise.BitAndFunction([literal_three, literal_ten]).eval()
+    assert result == 2
+
+
+def test_bitand_parse():
+    e = Function.parse(None, 'BITAND(1, 2)', 0)
+    assert isinstance(e, bitwise.BitAndFunction)
+
+
+def test_bitand_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITAND(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITAND(1, 2, 3)', 0)
+
+
+def test_bitor_simple(literal_three, literal_ten):
+    result = bitwise.BitOrFunction([literal_three, literal_ten]).eval()
+    assert result == 11
+
+
+def test_bitor_parse():
+    e = Function.parse(None, 'BITOR(1, 2)', 0)
+    assert isinstance(e, bitwise.BitOrFunction)
+
+
+def test_bitor_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITOR(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITOR(1, 2, 3)', 0)
+
+
+def test_bitnot_simple(literal_three):
+    result = bitwise.BitNotFunction([literal_three]).eval()
+    assert result == -4
+
+
+def test_bitnot_parse():
+    e = Function.parse(None, 'BITNOT(1)', 0)
+    assert isinstance(e, bitwise.BitNotFunction)
+
+
+def test_bitnot_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITNOT()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITNOT(1, 2)', 0)
+
+
+def test_bitxor_simple(literal_three, literal_ten):
+    result = bitwise.BitXOrFunction([literal_three, literal_ten]).eval()
+    assert result == 9
+
+
+def test_bitxor_parse():
+    e = Function.parse(None, 'BITXOR(1, 2)', 0)
+    assert isinstance(e, bitwise.BitXOrFunction)
+
+
+def test_bitxor_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITXOR(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BITXOR(1, 2, 3)', 0)
+
+
+def test_shl_simple(literal_three, literal_ten):
+    result = bitwise.SHLFunction([literal_three, literal_ten]).eval()
+    assert result == 3072
+
+
+def test_shl_parse():
+    e = Function.parse(None, 'SHL(1, 2)', 0)
+    assert isinstance(e, bitwise.SHLFunction)
+
+
+def test_shl_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SHL(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SHL(1, 2, 3)', 0)
+
+
+def test_shr_simple(literal_three, literal_ten):
+    result = bitwise.SHRFunction([literal_ten, literal_three]).eval()
+    assert result == 1
+
+
+def test_shr_parse():
+    e = Function.parse(None, 'SHR(1, 2)', 0)
+    assert isinstance(e, bitwise.SHRFunction)
+
+
+def test_shr_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SHR(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SHR(1, 2, 3)', 0)

--- a/tests/qtoggleserver/core/expressions/test_comparison.py
+++ b/tests/qtoggleserver/core/expressions/test_comparison.py
@@ -1,0 +1,197 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import comparison, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_if_boolean(literal_false, literal_true, literal_one, literal_two):
+    result = comparison.IfFunction([literal_false, literal_one, literal_two]).eval()
+    assert result == 2
+
+    result = comparison.IfFunction([literal_true, literal_one, literal_two]).eval()
+    assert result == 1
+
+
+def test_if_number(literal_zero, literal_one, literal_two):
+    result = comparison.IfFunction([literal_zero, literal_one, literal_two]).eval()
+    assert result == 2
+
+    result = comparison.IfFunction([literal_two, literal_one, literal_two]).eval()
+    assert result == 1
+
+
+def test_if_parse():
+    e = Function.parse(None, 'IF(1, 2, 3)', 0)
+    assert isinstance(e, comparison.IfFunction)
+
+
+def test_if_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'IF(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'IF(1, 2, 3, 4)', 0)
+
+
+def test_eq_boolean(literal_false, literal_true):
+    result = comparison.EqFunction([literal_false, literal_true]).eval()
+    assert result == 0
+
+    result = comparison.EqFunction([literal_false, literal_false]).eval()
+    assert result == 1
+
+
+def test_eq_number(literal_one, literal_two):
+    result = comparison.EqFunction([literal_one, literal_two]).eval()
+    assert result == 0
+
+    result = comparison.EqFunction([literal_two, literal_two]).eval()
+    assert result == 1
+
+
+def test_eq_parse():
+    e = Function.parse(None, 'EQ(1, 2)', 0)
+    assert isinstance(e, comparison.EqFunction)
+
+
+def test_eq_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'EQ(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'EQ(1, 2, 3)', 0)
+
+
+def test_gt_boolean(literal_false, literal_true):
+    result = comparison.GTFunction([literal_true, literal_false]).eval()
+    assert result == 1
+
+    result = comparison.GTFunction([literal_false, literal_false]).eval()
+    assert result == 0
+
+
+def test_gt_number(literal_one, literal_two):
+    result = comparison.GTFunction([literal_two, literal_one]).eval()
+    assert result == 1
+
+    result = comparison.GTFunction([literal_one, literal_two]).eval()
+    assert result == 0
+
+    result = comparison.GTFunction([literal_two, literal_two]).eval()
+    assert result == 0
+
+
+def test_gt_parse():
+    e = Function.parse(None, 'GT(1, 2)', 0)
+    assert isinstance(e, comparison.GTFunction)
+
+
+def test_gt_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'GT(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'GT(1, 2, 3)', 0)
+
+
+def test_gte_boolean(literal_false, literal_true):
+    result = comparison.GTEFunction([literal_true, literal_false]).eval()
+    assert result == 1
+
+    result = comparison.GTEFunction([literal_false, literal_false]).eval()
+    assert result == 1
+
+    result = comparison.GTEFunction([literal_false, literal_true]).eval()
+    assert result == 0
+
+
+def test_gte_number(literal_one, literal_two):
+    result = comparison.GTEFunction([literal_two, literal_one]).eval()
+    assert result == 1
+
+    result = comparison.GTEFunction([literal_one, literal_two]).eval()
+    assert result == 0
+
+    result = comparison.GTEFunction([literal_two, literal_two]).eval()
+    assert result == 1
+
+
+def test_gte_parse():
+    e = Function.parse(None, 'GTE(1, 2)', 0)
+    assert isinstance(e, comparison.GTEFunction)
+
+
+def test_gte_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'GTE(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'GTE(1, 2, 3)', 0)
+
+
+def test_lt_boolean(literal_false, literal_true):
+    result = comparison.LTFunction([literal_false, literal_true]).eval()
+    assert result == 1
+
+    result = comparison.LTFunction([literal_false, literal_false]).eval()
+    assert result == 0
+
+
+def test_lt_number(literal_one, literal_two):
+    result = comparison.LTFunction([literal_one, literal_two]).eval()
+    assert result == 1
+
+    result = comparison.LTFunction([literal_two, literal_one]).eval()
+    assert result == 0
+
+    result = comparison.LTFunction([literal_two, literal_two]).eval()
+    assert result == 0
+
+
+def test_lt_parse():
+    e = Function.parse(None, 'LT(1, 2)', 0)
+    assert isinstance(e, comparison.LTFunction)
+
+
+def test_lt_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LT(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LT(1, 2, 3)', 0)
+
+
+def test_lte_boolean(literal_false, literal_true):
+    result = comparison.LTEFunction([literal_false, literal_true]).eval()
+    assert result == 1
+
+    result = comparison.LTEFunction([literal_false, literal_false]).eval()
+    assert result == 1
+
+    result = comparison.LTEFunction([literal_true, literal_false]).eval()
+    assert result == 0
+
+
+def test_lte_number(literal_one, literal_two):
+    result = comparison.LTEFunction([literal_one, literal_two]).eval()
+    assert result == 1
+
+    result = comparison.LTEFunction([literal_two, literal_one]).eval()
+    assert result == 0
+
+    result = comparison.LTEFunction([literal_two, literal_two]).eval()
+    assert result == 1
+
+
+def test_lte_parse():
+    e = Function.parse(None, 'LTE(1, 2)', 0)
+    assert isinstance(e, comparison.LTEFunction)
+
+
+def test_lte_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LTE(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LTE(1, 2, 3)', 0)

--- a/tests/qtoggleserver/core/expressions/test_date.py
+++ b/tests/qtoggleserver/core/expressions/test_date.py
@@ -1,0 +1,660 @@
+
+import datetime
+import pytest
+
+from qtoggleserver.core.expressions import date, literalvalues, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_year_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.YearFunction([]).eval()
+    assert result == dummy_local_datetime.year
+
+
+def test_year_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.YearFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.year
+
+
+def test_year_parse():
+    e = Function.parse(None, 'YEAR()', 0)
+    assert isinstance(e, date.YearFunction)
+
+
+def test_year_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'YEAR(1, 2)', 0)
+
+
+def test_month_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.MonthFunction([]).eval()
+    assert result == dummy_local_datetime.month
+
+
+def test_month_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.MonthFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.month
+
+
+def test_month_parse():
+    e = Function.parse(None, 'MONTH()', 0)
+    assert isinstance(e, date.MonthFunction)
+
+
+def test_month_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MONTH(1, 2)', 0)
+
+
+def test_day_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.DayFunction([]).eval()
+    assert result == dummy_local_datetime.day
+
+
+def test_day_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.DayFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.day
+
+
+def test_day_parse():
+    e = Function.parse(None, 'DAY()', 0)
+    assert isinstance(e, date.DayFunction)
+
+
+def test_day_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DAY(1, 2)', 0)
+
+
+def test_dow_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.DOWFunction([]).eval()
+    assert result == dummy_local_datetime.weekday()
+
+
+def test_dow_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.DOWFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.weekday()
+
+
+def test_dow_parse():
+    e = Function.parse(None, 'DOW()', 0)
+    assert isinstance(e, date.DOWFunction)
+
+
+def test_dow_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DOW(1, 2)', 0)
+
+
+def test_ldom_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.LDOMFunction([]).eval()
+    assert result == 31
+
+
+def test_ldom_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.LDOMFunction([literal_dummy_timestamp]).eval()
+    assert result == 31
+
+
+def test_ldom_parse():
+    e = Function.parse(None, 'LDOM()', 0)
+    assert isinstance(e, date.LDOMFunction)
+
+
+def test_ldom_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LDOM(1, 2)', 0)
+
+
+def test_hour_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.HourFunction([]).eval()
+    assert result == dummy_local_datetime.hour
+
+
+def test_hour_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.HourFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.hour
+
+
+def test_hour_parse():
+    e = Function.parse(None, 'HOUR()', 0)
+    assert isinstance(e, date.HourFunction)
+
+
+def test_hour_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HOUR(1, 2)', 0)
+
+
+def test_minute_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.MinuteFunction([]).eval()
+    assert result == dummy_local_datetime.minute
+
+
+def test_minute_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.MinuteFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.minute
+
+
+def test_minute_parse():
+    e = Function.parse(None, 'MINUTE()', 0)
+    assert isinstance(e, date.MinuteFunction)
+
+
+def test_minute_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MINUTE(1, 2)', 0)
+
+
+def test_second_simple(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.SecondFunction([]).eval()
+    assert result == dummy_local_datetime.second
+
+
+def test_second_argument(dummy_local_datetime, literal_dummy_timestamp):
+    result = date.SecondFunction([literal_dummy_timestamp]).eval()
+    assert result == dummy_local_datetime.second
+
+
+def test_second_parse():
+    e = Function.parse(None, 'SECOND()', 0)
+    assert isinstance(e, date.SecondFunction)
+
+
+def test_second_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SECOND(1, 2)', 0)
+
+
+def test_millisecond(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+
+    result = date.MillisecondFunction([]).eval()
+    assert result == dummy_local_datetime.microsecond // 1000
+
+
+def test_millisecond_parse():
+    e = Function.parse(None, 'MILLISECOND()', 0)
+    assert isinstance(e, date.MillisecondFunction)
+
+
+def test_millisecond_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MILLISECOND(1)', 0)
+
+
+def test_date(dummy_local_datetime, dummy_timestamp):
+    result = date.DateFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.year, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second, '')
+    ]).eval()
+    assert result == int(dummy_timestamp)
+
+
+def test_date_parse():
+    e = Function.parse(None, 'DATE(2019, 3, 14, 1, 2, 3)', 0)
+    assert isinstance(e, date.DateFunction)
+
+
+def test_date_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DATE(2019, 3, 14, 1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DATE(2019, 3, 14, 1, 2, 3, 4)', 0)
+
+
+def test_boy_simple(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOYFunction([]).eval()
+
+    dt = dummy_local_datetime.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_boy_negative(freezer, dummy_local_datetime, dummy_timestamp, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOYFunction([literalvalues.LiteralValue(-30, '')]).eval()
+
+    dt = dummy_local_datetime.replace(
+        year=dummy_local_datetime.year - 30,
+        month=1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_boy_positive(freezer, dummy_local_datetime, dummy_timestamp, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOYFunction([literalvalues.LiteralValue(100, '')]).eval()
+
+    dt = dummy_local_datetime.replace(
+        year=dummy_local_datetime.year + 100,
+        month=1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_boy_parse():
+    e = Function.parse(None, 'BOY()', 0)
+    assert isinstance(e, date.BOYFunction)
+
+
+def test_boy_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BOY(1, 2)', 0)
+
+
+def test_bom_simple(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOMFunction([]).eval()
+
+    dt = dummy_local_datetime.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bom_negative(freezer, dummy_local_datetime, dummy_timestamp, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOMFunction([literalvalues.LiteralValue(-13, '')]).eval()
+
+    dt = dummy_local_datetime.replace(
+        year=dummy_local_datetime.year - 1,
+        month=dummy_local_datetime.month - 1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bom_positive(freezer, dummy_local_datetime, dummy_timestamp, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOMFunction([literalvalues.LiteralValue(13, '')]).eval()
+
+    dt = dummy_local_datetime.replace(
+        year=dummy_local_datetime.year + 1,
+        month=dummy_local_datetime.month + 1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bom_parse():
+    e = Function.parse(None, 'BOM()', 0)
+    assert isinstance(e, date.BOMFunction)
+
+
+def test_bom_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BOM(1, 2)', 0)
+
+
+def test_bow_simple(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([]).eval()
+
+    dt = dummy_local_datetime.replace(
+        day=dummy_local_datetime.day - dummy_local_datetime.weekday(),
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_negative(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([literalvalues.LiteralValue(-54, '')]).eval()
+
+    dt = datetime.datetime(2018, 2, 26, 0, 0, 0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_positive(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([literalvalues.LiteralValue(54, '')]).eval()
+
+    dt = datetime.datetime(2020, 3, 23, 0, 0, 0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_sunday(freezer, dummy_local_datetime, literal_zero, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([
+        literal_zero,
+        literalvalues.LiteralValue(6, '')
+    ]).eval()
+
+    dt = dummy_local_datetime.replace(
+        day=dummy_local_datetime.day - dummy_local_datetime.weekday() - 1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_sunday_negative(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([
+        literalvalues.LiteralValue(-54, ''),
+        literalvalues.LiteralValue(6, '')
+    ]).eval()
+
+    dt = datetime.datetime(2018, 2, 25, 0, 0, 0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_sunday_positive(freezer, dummy_local_datetime, local_tz_info):
+    freezer.move_to(dummy_local_datetime)
+    result = date.BOWFunction([
+        literalvalues.LiteralValue(54, ''),
+        literalvalues.LiteralValue(6, '')
+    ]).eval()
+
+    dt = datetime.datetime(2020, 3, 22, 0, 0, 0)
+    dt = dt.astimezone(local_tz_info)
+    assert result == dt.timestamp()
+
+
+def test_bow_parse():
+    e = Function.parse(None, 'BOW()', 0)
+    assert isinstance(e, date.BOWFunction)
+
+
+def test_bow_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'BOW(1, 2, 3)', 0)
+
+
+def test_hmsinterval_hours(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour - 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour + 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour - 2, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour - 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 0
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour + 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour + 2, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_hmsinterval_minutes(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute - 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute + 1, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute - 2, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute - 1, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 0
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute + 1, ''),
+        literalvalues.LiteralValue(0, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute + 2, ''),
+        literalvalues.LiteralValue(0, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_hmsinterval_seconds(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second + 1, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second - 2, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second - 1, '')
+    ]).eval()
+    assert result == 0
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second + 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second + 2, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_hmsinterval_limit(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second + 1, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second, '')
+    ]).eval()
+    assert result == 1
+
+
+def test_hmsinterval_reversed(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.HMSIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.hour + 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.hour - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.minute, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.second, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_hmsinterval_parse():
+    e = Function.parse(None, 'HMSINTERVAL(1, 1, 1, 2, 2, 2)', 0)
+    assert isinstance(e, date.HMSIntervalFunction)
+
+
+def test_hmsinterval_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HMSINTERVAL(1, 2, 3, 4, 5)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HMSINTERVAL(1, 2, 3, 4, 5, 6, 7)', 0)
+
+
+def test_mdinterval_months(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month - 1, ''),
+        literalvalues.LiteralValue(1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month + 1, ''),
+        literalvalues.LiteralValue(1, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month - 2, ''),
+        literalvalues.LiteralValue(1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month - 1, ''),
+        literalvalues.LiteralValue(1, '')
+    ]).eval()
+    assert result == 0
+
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month + 1, ''),
+        literalvalues.LiteralValue(1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month + 2, ''),
+        literalvalues.LiteralValue(1, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_mdinterval_days(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day + 1, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day - 2, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day - 1, '')
+    ]).eval()
+    assert result == 0
+
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day + 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day + 2, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_mdinterval_limit(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day + 1, '')
+    ]).eval()
+    assert result == 1
+
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day, '')
+    ]).eval()
+    assert result == 1
+
+
+def test_mdinterval_reversed(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    result = date.MDIntervalFunction([
+        literalvalues.LiteralValue(dummy_local_datetime.month + 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.month - 1, ''),
+        literalvalues.LiteralValue(dummy_local_datetime.day, '')
+    ]).eval()
+    assert result == 0
+
+
+def test_mdinterval_parse():
+    e = Function.parse(None, 'MDINTERVAL(1, 1, 2, 2)', 0)
+    assert isinstance(e, date.MDIntervalFunction)
+
+
+def test_mdinterval_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MDINTERVAL(1, 2, 3)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'MDINTERVAL(1, 2, 3, 4, 5)', 0)

--- a/tests/qtoggleserver/core/expressions/test_logic.py
+++ b/tests/qtoggleserver/core/expressions/test_logic.py
@@ -1,0 +1,143 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import logic, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_and_simple(literal_false, literal_true):
+    result = logic.AndFunction([literal_false, literal_true]).eval()
+    assert result == 0
+
+    result = logic.AndFunction([literal_false, literal_false]).eval()
+    assert result == 0
+
+    result = logic.AndFunction([literal_true, literal_true]).eval()
+    assert result == 1
+
+
+def test_and_multiple(literal_false, literal_true):
+    result = logic.AndFunction([literal_false, literal_true, literal_true]).eval()
+    assert result == 0
+
+    result = logic.AndFunction([literal_true, literal_true, literal_true]).eval()
+    assert result == 1
+
+
+def test_and_number(literal_zero, literal_ten, literal_true):
+    result = logic.AndFunction([literal_zero, literal_true]).eval()
+    assert result == 0
+
+    result = logic.AndFunction([literal_ten, literal_true]).eval()
+    assert result == 1
+
+
+def test_and_parse():
+    e = Function.parse(None, 'AND(false, true)', 0)
+    assert isinstance(e, logic.AndFunction)
+
+
+def test_and_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'AND(false)', 0)
+
+
+def test_or_simple(literal_false, literal_true):
+    result = logic.OrFunction([literal_false, literal_false]).eval()
+    assert result == 0
+
+    result = logic.OrFunction([literal_false, literal_true]).eval()
+    assert result == 1
+
+    result = logic.OrFunction([literal_true, literal_true]).eval()
+    assert result == 1
+
+
+def test_or_multiple(literal_false, literal_true):
+    result = logic.OrFunction([literal_false, literal_false, literal_false]).eval()
+    assert result == 0
+
+    result = logic.OrFunction([literal_false, literal_true, literal_false]).eval()
+    assert result == 1
+
+
+def test_or_number(literal_zero, literal_ten, literal_true, literal_false):
+    result = logic.OrFunction([literal_zero, literal_true]).eval()
+    assert result == 1
+
+    result = logic.OrFunction([literal_ten, literal_false]).eval()
+    assert result == 1
+
+
+def test_or_parse():
+    e = Function.parse(None, 'OR(false, true)', 0)
+    assert isinstance(e, logic.OrFunction)
+
+
+def test_or_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'OR(false)', 0)
+
+
+def test_not_simple(literal_false, literal_true):
+    result = logic.NotFunction([literal_false]).eval()
+    assert result == 1
+
+    result = logic.NotFunction([literal_true]).eval()
+    assert result == 0
+
+
+def test_not_number(literal_zero, literal_ten):
+    result = logic.NotFunction([literal_zero]).eval()
+    assert result == 1
+
+    result = logic.NotFunction([literal_ten]).eval()
+    assert result == 0
+
+
+def test_not_parse():
+    e = Function.parse(None, 'NOT(false)', 0)
+    assert isinstance(e, logic.NotFunction)
+
+
+def test_not_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'NOT()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'NOT(false, true)', 0)
+
+
+def test_xor_simple(literal_false, literal_true):
+    result = logic.XOrFunction([literal_false, literal_false]).eval()
+    assert result == 0
+
+    result = logic.XOrFunction([literal_false, literal_true]).eval()
+    assert result == 1
+
+    result = logic.XOrFunction([literal_true, literal_true]).eval()
+    assert result == 0
+
+
+def test_xor_number(literal_zero, literal_ten, literal_true, literal_false):
+    result = logic.XOrFunction([literal_zero, literal_true]).eval()
+    assert result == 1
+
+    result = logic.XOrFunction([literal_ten, literal_false]).eval()
+    assert result == 1
+
+    result = logic.XOrFunction([literal_ten, literal_true]).eval()
+    assert result == 0
+
+
+def test_xor_parse():
+    e = Function.parse(None, 'XOR(false, true)', 0)
+    assert isinstance(e, logic.XOrFunction)
+
+
+def test_xor_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'XOR(false)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'XOR(false, true, false)', 0)

--- a/tests/qtoggleserver/core/expressions/test_rounding.py
+++ b/tests/qtoggleserver/core/expressions/test_rounding.py
@@ -1,0 +1,112 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import rounding, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_floor_integer(literal_two):
+    result = rounding.FloorFunction([literal_two]).eval()
+    assert result == 2
+
+
+def test_floor_positive(literal_pi, literal_ten_point_fifty_one):
+    result = rounding.FloorFunction([literal_pi]).eval()
+    assert result == 3
+
+    result = rounding.FloorFunction([literal_ten_point_fifty_one]).eval()
+    assert result == 10
+
+
+def test_floor_negative(literal_minus_pi, literal_minus_ten_point_fifty_one):
+    result = rounding.FloorFunction([literal_minus_pi]).eval()
+    assert result == -4
+
+    result = rounding.FloorFunction([literal_minus_ten_point_fifty_one]).eval()
+    assert result == -11
+
+
+def test_floor_parse():
+    e = Function.parse(None, 'FLOOR(1)', 0)
+    assert isinstance(e, rounding.FloorFunction)
+
+
+def test_floor_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FLOOR()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FLOOR(1, 2)', 0)
+
+
+def test_ceil_integer(literal_two):
+    result = rounding.CeilFunction([literal_two]).eval()
+    assert result == 2
+
+
+def test_ceil_positive(literal_pi, literal_ten_point_fifty_one):
+    result = rounding.CeilFunction([literal_pi]).eval()
+    assert result == 4
+
+    result = rounding.CeilFunction([literal_ten_point_fifty_one]).eval()
+    assert result == 11
+
+
+def test_ceil_negative(literal_minus_pi, literal_minus_ten_point_fifty_one):
+    result = rounding.CeilFunction([literal_minus_pi]).eval()
+    assert result == -3
+
+    result = rounding.CeilFunction([literal_minus_ten_point_fifty_one]).eval()
+    assert result == -10
+
+
+def test_ceil_parse():
+    e = Function.parse(None, 'CEIL(1)', 0)
+    assert isinstance(e, rounding.CeilFunction)
+
+
+def test_ceil_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'CEIL()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'CEIL(1, 2)', 0)
+
+
+def test_round_integer(literal_two):
+    result = rounding.RoundFunction([literal_two]).eval()
+    assert result == 2
+
+
+def test_round_positive(literal_pi, literal_ten_point_fifty_one):
+    result = rounding.RoundFunction([literal_pi]).eval()
+    assert result == 3
+
+    result = rounding.RoundFunction([literal_ten_point_fifty_one]).eval()
+    assert result == 11
+
+
+def test_round_negative(literal_minus_pi, literal_minus_ten_point_fifty_one):
+    result = rounding.RoundFunction([literal_minus_pi]).eval()
+    assert result == -3
+
+    result = rounding.RoundFunction([literal_minus_ten_point_fifty_one]).eval()
+    assert result == -11
+
+
+def test_round_decimals(literal_minus_pi, literal_two):
+    result = rounding.RoundFunction([literal_minus_pi, literal_two]).eval()
+    assert result == -3.14
+
+
+def test_round_parse():
+    e = Function.parse(None, 'ROUND(1)', 0)
+    assert isinstance(e, rounding.RoundFunction)
+
+
+def test_round_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ROUND()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ROUND(1, 2, 3)', 0)

--- a/tests/qtoggleserver/core/expressions/test_sign.py
+++ b/tests/qtoggleserver/core/expressions/test_sign.py
@@ -1,0 +1,47 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import sign, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_abs(literal_two, literal_minus_two):
+    result = sign.AbsFunction([literal_two]).eval()
+    assert result == 2
+
+    result = sign.AbsFunction([literal_minus_two]).eval()
+    assert result == 2
+
+
+def test_abs_parse():
+    e = Function.parse(None, 'ABS(1)', 0)
+    assert isinstance(e, sign.AbsFunction)
+
+
+def test_abs_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ABS()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ABS(1, 2)', 0)
+
+
+def test_sgn(literal_two, literal_minus_two):
+    result = sign.SgnFunction([literal_two]).eval()
+    assert result == 1
+
+    result = sign.SgnFunction([literal_minus_two]).eval()
+    assert result == -1
+
+
+def test_sgn_parse():
+    e = Function.parse(None, 'SGN(1)', 0)
+    assert isinstance(e, sign.SgnFunction)
+
+
+def test_sgn_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SGN()', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SGN(1, 2)', 0)

--- a/tests/qtoggleserver/core/expressions/test_time.py
+++ b/tests/qtoggleserver/core/expressions/test_time.py
@@ -1,0 +1,39 @@
+
+import pytest
+
+from qtoggleserver.core.expressions import time, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+
+def test_time(freezer, dummy_utc_datetime, dummy_timestamp):
+    freezer.move_to(dummy_utc_datetime)
+
+    result = time.TimeFunction([]).eval()
+    assert result == int(dummy_timestamp)
+
+
+def test_time_parse():
+    e = Function.parse(None, 'TIME()', 0)
+    assert isinstance(e, time.TimeFunction)
+
+
+def test_time_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'TIME(1)', 0)
+
+
+def test_timems(freezer, dummy_utc_datetime, dummy_timestamp):
+    freezer.move_to(dummy_utc_datetime)
+
+    result = time.TimeMSFunction([]).eval()
+    assert result == int(dummy_timestamp * 1000)
+
+
+def test_timems_parse():
+    e = Function.parse(None, 'TIMEMS()', 0)
+    assert isinstance(e, time.TimeMSFunction)
+
+
+def test_timems_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'TIMEMS(1)', 0)

--- a/tests/qtoggleserver/core/expressions/test_timeprocessing.py
+++ b/tests/qtoggleserver/core/expressions/test_timeprocessing.py
@@ -1,0 +1,415 @@
+
+import datetime
+
+import pytest
+
+from qtoggleserver.core.expressions import timeprocessing, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments, EvalSkipped
+
+from .mock import MockExpression
+
+
+def test_delay(freezer, dummy_local_datetime, literal_one_thousand):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(3)
+    expr = timeprocessing.DelayFunction([value_expr, literal_one_thousand])
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=100))
+    assert expr.eval() == 3
+
+    value_expr.set_value(16)
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=500))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1499))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1501))
+    assert expr.eval() == 16
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=10000))
+    assert expr.eval() == 16
+
+
+def test_delay_parse():
+    e = Function.parse(None, 'DELAY(1, 2)', 0)
+    assert isinstance(e, timeprocessing.DelayFunction)
+
+
+def test_delay_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DELAY(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DELAY(1, 2, 3)', 0)
+
+
+def test_sample(freezer, dummy_local_datetime, literal_one_thousand):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(3)
+    expr = timeprocessing.SampleFunction([value_expr, literal_one_thousand])
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=100))
+    value_expr.set_value(16)
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=500))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=999))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1001))
+    assert expr.eval() == 16
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=10000))
+    assert expr.eval() == 16
+
+
+def test_sample_parse():
+    e = Function.parse(None, 'SAMPLE(1, 2)', 0)
+    assert isinstance(e, timeprocessing.SampleFunction)
+
+
+def test_sample_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SAMPLE(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SAMPLE(1, 2, 3)', 0)
+
+
+def test_freeze(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(1)
+    time_expr = MockExpression(200)
+    expr = timeprocessing.FreezeFunction([value_expr, time_expr])
+    assert expr.eval() == 1
+    time_expr.set_value(50)
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=100))
+    value_expr.set_value(2)
+    assert expr.eval() == 1
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=199))
+    assert expr.eval() == 1
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=201))
+    time_expr.set_value(200)
+    assert expr.eval() == 2
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=500))
+    value_expr.set_value(3)
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=600))
+    value_expr.set_value(4)
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=699))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=701))
+    assert expr.eval() == 4
+
+
+def test_freeze_parse():
+    e = Function.parse(None, 'FREEZE(1, 2)', 0)
+    assert isinstance(e, timeprocessing.FreezeFunction)
+
+
+def test_freeze_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FREEZE(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FREEZE(1, 2, 3)', 0)
+
+
+def test_held_fulfilled(freezer, dummy_local_datetime, literal_sixteen):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(16)
+    time_expr = MockExpression(200)
+    expr = timeprocessing.HeldFunction([value_expr, literal_sixteen, time_expr])
+    assert expr.eval() == 0
+    time_expr.set_value(500)
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=499))
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=501))
+    assert expr.eval() == 1
+
+
+def test_held_not_fulfilled(freezer, dummy_local_datetime, literal_sixteen):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(16)
+    time_expr = MockExpression(200)
+    expr = timeprocessing.HeldFunction([value_expr, literal_sixteen, time_expr])
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=100))
+    value_expr.set_value(15)
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=201))
+    assert expr.eval() == 0
+
+
+def test_held_different_value(freezer, dummy_local_datetime, literal_sixteen):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(15)
+    time_expr = MockExpression(200)
+    expr = timeprocessing.HeldFunction([value_expr, literal_sixteen, time_expr])
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=501))
+    assert expr.eval() == 0
+
+
+def test_held_parse():
+    e = Function.parse(None, 'HELD(1, 2, 3)', 0)
+    assert isinstance(e, timeprocessing.HeldFunction)
+
+
+def test_held_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HELD(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HELD(1, 2, 3, 4)', 0)
+
+
+def test_deriv(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(0)
+    time_expr = MockExpression(100)
+    expr = timeprocessing.DerivFunction([value_expr, time_expr])
+    assert round(expr.eval(), 1) == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=200))
+    value_expr.set_value(1)
+    assert round(expr.eval(), 1) == 5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=300))
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=400))
+    value_expr.set_value(2)
+    assert round(expr.eval(), 1) == 5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=800))
+    value_expr.set_value(5)
+    time_expr.set_value(200)
+    assert round(expr.eval(), 1) == 7.5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1000))
+    value_expr.set_value(1)
+    time_expr.set_value(100)
+    assert round(expr.eval(), 1) == -20
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1200))
+    assert round(expr.eval(), 1) == 0
+
+
+def test_deriv_parse():
+    e = Function.parse(None, 'DERIV(1, 2)', 0)
+    assert isinstance(e, timeprocessing.DerivFunction)
+
+
+def test_deriv_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DERIV(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'DERIV(1, 2, 3)', 0)
+
+
+def test_integ(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    acc_expr = MockExpression(0)
+    value_expr = MockExpression(0)
+    time_expr = MockExpression(100)
+    expr = timeprocessing.IntegFunction([value_expr, acc_expr, time_expr])
+    assert round(expr.eval(), 1) == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=200))
+    value_expr.set_value(10)
+    assert round(expr.eval(), 1) == 1
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=300))
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=400))
+    acc_expr.set_value(1)
+    assert round(expr.eval(), 1) == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=800))
+    value_expr.set_value(15)
+    acc_expr.set_value(3)
+    time_expr.set_value(200)
+    assert round(expr.eval(), 1) == 8
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1000))
+    value_expr.set_value(-20)
+    acc_expr.set_value(8)
+    time_expr.set_value(100)
+    assert round(expr.eval(), 1) == 7.5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=1200))
+    value_expr.set_value(0)
+    acc_expr.set_value(7.5)
+    assert round(expr.eval(), 1) == 5.5
+
+
+def test_integ_parse():
+    e = Function.parse(None, 'INTEG(1, 2, 3)', 0)
+    assert isinstance(e, timeprocessing.IntegFunction)
+
+
+def test_integ_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'INTEG(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'INTEG(1, 2, 3, 4)', 0)
+
+
+def test_fmavg(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(0)
+    width_expr = MockExpression(4)
+    time_expr = MockExpression(100)
+    expr = timeprocessing.FMAvgFunction([value_expr, width_expr, time_expr])
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=101))
+    value_expr.set_value(8)
+    assert expr.eval() == 4
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=200))
+    value_expr.set_value(4)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=202))
+    assert expr.eval() == 4
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=301))
+    value_expr.set_value(-2)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=303))
+    assert expr.eval() == 2.5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=402))
+    value_expr.set_value(6)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=504))
+    assert expr.eval() == 4
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=603))
+    value_expr.set_value(11)
+    width_expr.set_value(3)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=605))
+    assert expr.eval() == 5
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=804))
+    value_expr.set_value(-8)
+    time_expr.set_value(200)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=806))
+    assert expr.eval() == 3
+
+
+def test_fmavg_parse():
+    e = Function.parse(None, 'FMAVG(1, 2, 3)', 0)
+    assert isinstance(e, timeprocessing.FMAvgFunction)
+
+
+def test_fmavg_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FMAVG(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FMAVG(1, 2, 3, 4)', 0)
+
+
+def test_fmedian(freezer, dummy_local_datetime):
+    freezer.move_to(dummy_local_datetime)
+    value_expr = MockExpression(0)
+    width_expr = MockExpression(4)
+    time_expr = MockExpression(100)
+    expr = timeprocessing.FMedianFunction([value_expr, width_expr, time_expr])
+    assert expr.eval() == 0
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=101))
+    value_expr.set_value(8)
+    assert expr.eval() == 8
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=200))
+    value_expr.set_value(4)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=202))
+    assert expr.eval() == 4
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=301))
+    value_expr.set_value(-2)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=303))
+    assert expr.eval() == 4
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=402))
+    value_expr.set_value(6)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=504))
+    assert expr.eval() == 6
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=603))
+    value_expr.set_value(11)
+    width_expr.set_value(3)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=605))
+    assert expr.eval() == 6
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=804))
+    value_expr.set_value(-8)
+    time_expr.set_value(200)
+    with pytest.raises(EvalSkipped):
+        expr.eval()
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=806))
+    assert expr.eval() == 6
+
+
+def test_fmedian_parse():
+    e = Function.parse(None, 'FMEDIAN(1, 2, 3)', 0)
+    assert isinstance(e, timeprocessing.FMedianFunction)
+
+
+def test_fmedian_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FMEDIAN(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'FMEDIAN(1, 2, 3, 4)', 0)

--- a/tests/qtoggleserver/core/expressions/test_various.py
+++ b/tests/qtoggleserver/core/expressions/test_various.py
@@ -1,0 +1,320 @@
+
+import datetime
+import pytest
+
+from qtoggleserver.core.expressions import various, Function
+from qtoggleserver.core.expressions import InvalidNumberOfArguments
+
+from .mock import MockExpression
+
+
+def test_acc():
+    value_expr = MockExpression(16)
+    acc_expr = MockExpression(13)
+    expr = various.AccFunction([value_expr, acc_expr])
+    assert expr.eval() == 13
+
+    acc_expr.set_value(-5)
+    assert expr.eval() == -5
+
+    value_expr.set_value(26)
+    assert expr.eval() == 5
+
+    value_expr.set_value(20)
+    acc_expr.set_value(5)
+    assert expr.eval() == -1
+
+
+def test_acc_parse():
+    e = Function.parse(None, 'ACC(1, 2)', 0)
+    assert isinstance(e, various.AccFunction)
+
+
+def test_acc_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ACC(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ACC(1, 2, 3)', 0)
+
+
+def test_accinc():
+    value_expr = MockExpression(16)
+    acc_expr = MockExpression(13)
+    expr = various.AccIncFunction([value_expr, acc_expr])
+    assert expr.eval() == 13
+
+    acc_expr.set_value(-5)
+    assert expr.eval() == -5
+
+    value_expr.set_value(26)
+    assert expr.eval() == 5
+
+    value_expr.set_value(20)
+    acc_expr.set_value(5)
+    assert expr.eval() == 5
+
+
+def test_accinc_parse():
+    e = Function.parse(None, 'ACCINC(1, 2)', 0)
+    assert isinstance(e, various.AccIncFunction)
+
+
+def test_accinc_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ACCINC(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'ACCINC(1, 2, 3)', 0)
+
+
+def test_hyst_rise(literal_three, literal_sixteen):
+    value_expr = MockExpression(1)
+    expr = various.HystFunction([value_expr, literal_three, literal_sixteen])
+    assert expr.eval() == 0
+
+    value_expr.set_value(2)
+    assert expr.eval() == 0
+
+    value_expr.set_value(3)
+    assert expr.eval() == 0
+
+    value_expr.set_value(4)
+    assert expr.eval() == 0
+
+    value_expr.set_value(16)
+    assert expr.eval() == 0
+
+    value_expr.set_value(10)
+    assert expr.eval() == 0
+
+    value_expr.set_value(2)
+    assert expr.eval() == 0
+
+    value_expr.set_value(17)
+    assert expr.eval() == 1
+
+    value_expr.set_value(20)
+    assert expr.eval() == 1
+
+
+def test_hyst_fall(literal_three, literal_sixteen):
+    value_expr = MockExpression(20)
+    expr = various.HystFunction([value_expr, literal_three, literal_sixteen])
+    assert expr.eval() == 1
+
+    value_expr.set_value(17)
+    assert expr.eval() == 1
+
+    value_expr.set_value(16)
+    assert expr.eval() == 1
+
+    value_expr.set_value(10)
+    assert expr.eval() == 1
+
+    value_expr.set_value(4)
+    assert expr.eval() == 1
+
+    value_expr.set_value(20)
+    assert expr.eval() == 1
+
+    value_expr.set_value(3)
+    assert expr.eval() == 1
+
+    value_expr.set_value(2)
+    assert expr.eval() == 0
+
+    value_expr.set_value(0)
+    assert expr.eval() == 0
+
+
+def test_hyst_parse():
+    e = Function.parse(None, 'HYST(1, 2, 3)', 0)
+    assert isinstance(e, various.HystFunction)
+
+
+def test_hyst_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HYST(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'HYST(1, 2, 3, 4)', 0)
+
+
+def test_sequence(
+    freezer,
+    dummy_local_datetime,
+    literal_two,
+    literal_three,
+    literal_sixteen,
+    literal_one_hundred,
+    literal_two_hundreds
+):
+    freezer.move_to(dummy_local_datetime)
+    expr = various.SequenceFunction([
+        literal_three,
+        literal_one_hundred,
+        literal_sixteen,
+        literal_two_hundreds,
+        literal_two,
+        literal_one_hundred
+    ])
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=99))
+    assert expr.eval() == 3
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=101))
+    assert expr.eval() == 16
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=200))
+    assert expr.eval() == 16
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=299))
+    assert expr.eval() == 16
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=301))
+    assert expr.eval() == 2
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=399))
+    assert expr.eval() == 2
+
+    freezer.move_to(dummy_local_datetime + datetime.timedelta(milliseconds=401))
+    assert expr.eval() == 3
+
+
+def test_sequence_parse():
+    e = Function.parse(None, 'SEQUENCE(1, 2, 3, 4)', 0)
+    assert isinstance(e, various.SequenceFunction)
+
+
+def test_sequence_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'SEQUENCE(1)', 0)
+
+
+def test_lut(
+    freezer,
+    literal_two,
+    literal_three,
+    literal_sixteen,
+    literal_one_hundred,
+    literal_two_hundreds,
+    literal_one_thousand
+):
+    value_expr = MockExpression(0)
+    expr = various.LUTFunction([
+        value_expr,
+        literal_three,
+        literal_two_hundreds,
+        literal_sixteen,
+        literal_one_thousand,
+        literal_two,
+        literal_one_hundred
+    ])
+    assert expr.eval() == 100
+
+    value_expr.set_value(2)
+    assert expr.eval() == 100
+
+    value_expr.set_value(2.4)
+    assert expr.eval() == 100
+
+    value_expr.set_value(2.6)
+    assert expr.eval() == 200
+
+    value_expr.set_value(3)
+    assert expr.eval() == 200
+
+    value_expr.set_value(5)
+    assert expr.eval() == 200
+
+    value_expr.set_value(9.4)
+    assert expr.eval() == 200
+
+    value_expr.set_value(9.6)
+    assert expr.eval() == 1000
+
+    value_expr.set_value(100)
+    assert expr.eval() == 1000
+
+
+def test_lut_parse():
+    e = Function.parse(None, 'LUT(1, 2, 3, 4, 5)', 0)
+    assert isinstance(e, various.LUTFunction)
+
+
+def test_lut_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUT(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUT(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUT(1, 2, 3, 4)', 0)
+
+
+def test_lutli(
+    freezer,
+    literal_two,
+    literal_three,
+    literal_sixteen,
+    literal_one_hundred,
+    literal_two_hundreds,
+    literal_one_thousand
+):
+    value_expr = MockExpression(0)
+    expr = various.LUTLIFunction([
+        value_expr,
+        literal_three,
+        literal_two_hundreds,
+        literal_sixteen,
+        literal_one_thousand,
+        literal_two,
+        literal_one_hundred
+    ])
+    assert expr.eval() == 100
+
+    value_expr.set_value(2)
+    assert expr.eval() == 100
+
+    value_expr.set_value(2.4)
+    assert expr.eval() == 140
+
+    value_expr.set_value(2.6)
+    assert expr.eval() == 160
+
+    value_expr.set_value(3)
+    assert expr.eval() == 200
+
+    value_expr.set_value(5)
+    assert round(expr.eval(), 2) == 323.08
+
+    value_expr.set_value(9.4)
+    assert round(expr.eval(), 2) == 593.85
+
+    value_expr.set_value(9.6)
+    assert round(expr.eval(), 2) == 606.15
+
+    value_expr.set_value(16)
+    assert round(expr.eval(), 2) == 1000
+
+    value_expr.set_value(100)
+    assert round(expr.eval(), 2) == 1000
+
+
+def test_lutli_parse():
+    e = Function.parse(None, 'LUTLI(1, 2, 3, 4, 5)', 0)
+    assert isinstance(e, various.LUTLIFunction)
+
+
+def test_lutli_num_args():
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUTLI(1)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUTLI(1, 2)', 0)
+
+    with pytest.raises(InvalidNumberOfArguments):
+        Function.parse(None, 'LUTLI(1, 2, 3, 4)', 0)


### PR DESCRIPTION
 * core/expressions: Add and use ExpressionArithmeticError
 * core/expressions: Add tests for arithmetic functions
 * core/expressions: Add tests for logic functions
 * core/expressions: Add tests for bitwise functions
 * core/expressions: Add tests for comparison functions
 * core/expressions: Add tests for sign functions
 * core/expressions: Add tests for aggregation functions
 * core/expressions: Add tests for rounding functions
 * core/expressions: Add tests for time functions
 * core/expressions: Add tests for date functions
 * core/expressions: Add tests for time-processing functions
 * core/expressions: Add tests for various functions
 * core/expressions: Fix various edge cases