### PR TITLE
frontend/ports/port-history-chart-page: Add min/max chart options

### DIFF
--- a/qtoggleserver/frontend/js/common/chart-page.js
+++ b/qtoggleserver/frontend/js/common/chart-page.js
@@ -5,6 +5,7 @@ import {gettext}             from '$qui/base/i18n.js'
 import {mix}                 from '$qui/base/mixwith.js'
 import {CheckField}          from '$qui/forms/common-fields/common-fields.js'
 import {ChoiceButtonsField}  from '$qui/forms/common-fields/common-fields.js'
+import {NumericField}        from '$qui/forms/common-fields/common-fields.js'
 import {OptionsForm}         from '$qui/forms/common-forms/common-forms.js'
 import StockIcon             from '$qui/icons/stock-icon.js'
 import {StructuredPageMixin} from '$qui/pages/common-pages/common-pages.js'
@@ -35,6 +36,7 @@ export class ChartPageOptionsForm extends OptionsForm {
      * @param {Boolean} [enableSmooth]
      * @param {Boolean} [enableFillArea]
      * @param {Boolean} [enableShowDataPoints]
+     * @param {Boolean} [enableMinMax]
      * @param {?String} [prefsPrefix]
      * @param {Object} [defaults]
      */
@@ -43,6 +45,7 @@ export class ChartPageOptionsForm extends OptionsForm {
         enableSmooth = true,
         enableFillArea = true,
         enableShowDataPoints = true,
+        enableMinMax = false,
         prefsPrefix = null,
         defaults = {}
     }) {
@@ -69,6 +72,20 @@ export class ChartPageOptionsForm extends OptionsForm {
                     {value: null, label: gettext('Auto')},
                     {value: true, label: gettext('On')}
                 ]
+            }))
+        }
+        if (enableMinMax) {
+            fields.push(new NumericField({
+                name: 'max',
+                label: gettext('Maximum'),
+                description: gettext('Higher chart limit. Clear value for automatic adjustment.'),
+                required: false
+            }))
+            fields.push(new NumericField({
+                name: 'min',
+                label: gettext('Minimum'),
+                description: gettext('Lower chart limit. Clear value for automatic adjustment.'),
+                required: false
             }))
         }
 
@@ -145,6 +162,18 @@ class ChartPage extends mix().with(StructuredPageMixin, ProgressViewMixin) {
         })
         this._data = data
         this.widgetCall = null
+
+        let panZoomMode = this._chartOptions.panZoomMode
+        if (panZoomMode) {
+            if (panZoomMode.includes('x')) {
+                delete this._chartOptions.xMin
+                delete this._chartOptions.xMax
+            }
+            if (panZoomMode.includes('y')) {
+                delete this._chartOptions.yMin
+                delete this._chartOptions.yMax
+            }
+        }
     }
 
     initHTML(html) {
@@ -185,6 +214,18 @@ class ChartPage extends mix().with(StructuredPageMixin, ProgressViewMixin) {
         }
         if ('showDataPoints' in options) {
             widgetOptions.showDataPoints = options['showDataPoints']
+        }
+        if (options['min'] != null) {
+            widgetOptions.yMin = options['min']
+        }
+        else {
+            widgetOptions.yMin = null
+        }
+        if (options['max'] != null) {
+            widgetOptions.yMax = options['max']
+        }
+        else {
+            widgetOptions.yMax = null
         }
 
         if (Object.keys(widgetOptions).length > 0) {
@@ -292,6 +333,14 @@ class ChartPage extends mix().with(StructuredPageMixin, ProgressViewMixin) {
      */
     getYRange() {
         return this.widgetCall('getYRange')
+    }
+
+    /**
+     * @param {Number} yMin
+     * @param {Number} yMax
+     */
+    setYRange(yMin, yMax) {
+        return this.widgetCall('setYRange', yMin, yMax)
     }
 
 }

--- a/qtoggleserver/frontend/js/ports/port-history-chart-page.js
+++ b/qtoggleserver/frontend/js/ports/port-history-chart-page.js
@@ -88,6 +88,11 @@ class PortHistoryChartPage extends ChartPage {
     }
 
     fetchAndShowHistory(from, to) {
+        let delta = to - from
+        let margin = delta * 0.1 /* 10% margin to the left as well as to the right of the interval */
+        to += margin
+        from -= margin
+
         this.setProgress()
 
         let fetchPromise = this._historyDownloadManager.fetch(Math.round(from), Math.round(to), MAX_FETCH_REQUESTS)
@@ -217,17 +222,29 @@ class PortHistoryChartPage extends ChartPage {
     }
 
     makeOptionsBarContent() {
+        let defaults = {
+            smooth: false,
+            fillArea: false,
+            showDataPoints: false
+        }
+
+        if (!this._isBoolean) {
+            if (this._port['min'] != null) {
+                defaults['min'] = this._port['min']
+            }
+            if (this._port['max'] != null) {
+                defaults['max'] = this._port['max']
+            }
+        }
+
         return new PortHistoryChartPageOptionsForm({
             chartPage: this,
             enableSmooth: !this._isBoolean,
             enableFillArea: true,
             enableShowDataPoints: true,
+            enableMinMax: true,
             prefsPrefix: `ports.${this._port['id']}.history_chart`,
-            defaults: {
-                smooth: false,
-                fillArea: false,
-                showDataPoints: false
-            }
+            defaults: defaults
         })
     }
 

--- a/qtoggleserver/frontend/js/widgets/base-chart.js
+++ b/qtoggleserver/frontend/js/widgets/base-chart.js
@@ -475,8 +475,10 @@ $.widget('qtoggle.basechart', $.qui.basewidget, {
                 return
             }
 
-            if (min != null && max != null) {
+            if (min != null && scale.min === undefined) {
                 scale.min = min
+            }
+            if (max != null && scale.max === undefined) {
                 scale.max = max
             }
         })

--- a/qtoggleserver/frontend/js/widgets/line-chart.js
+++ b/qtoggleserver/frontend/js/widgets/line-chart.js
@@ -43,24 +43,18 @@ $.widget('qtoggle.linechart', $.qtoggle.basechart, {
     },
 
     _makeScalesOptions: function (environment) {
-        /* min/max values must be supplied as undefined if not specified */
-        let xMin = this.options.xMin == null ? undefined : this.options.xMin
-        let xMax = this.options.xMax == null ? undefined : this.options.xMax
-        let yMin = this.options.yMin == null ? undefined : this.options.yMin
-        let yMax = this.options.yMax == null ? undefined : this.options.yMax
-
         return ObjectUtils.combine(this._super(environment), {
             x: {
                 type: 'linear',
-                min: xMin,
-                max: xMax,
+                min: this.options.xMin,
+                max: this.options.xMax,
                 gridLines: this._makeGridLinesOptions(environment),
                 ticks: this._makeTicksOptions(environment, 'x')
             },
             y: {
                 type: 'linear',
-                min: yMin,
-                max: yMax,
+                min: this.options.yMin,
+                max: this.options.yMax,
                 gridLines: this._makeGridLinesOptions(environment),
                 ticks: this._makeTicksOptions(environment, 'y')
             }


### PR DESCRIPTION
 * frontend/widgets: Allow partially specifying min/max for scales
 * frontend/ports/port-history-chart-page: Add min/max chart options
 * frontend/ports/port-history-chart-page: Allow extra 10% margin prefetch